### PR TITLE
Sdt 914 add sidebar navigation

### DIFF
--- a/application/scss/components/_pane.scss
+++ b/application/scss/components/_pane.scss
@@ -51,11 +51,14 @@
 
   .app-pane__subnav {
     border-right: 1px solid $govuk-border-colour;
+    padding: govuk-spacing(6) 0 govuk-spacing(6) govuk-spacing(6);
+
     @include govuk-media-query($from: tablet) {
       width: $toc-width-tablet;
       border-right: 1px solid $govuk-border-colour;
       flex: 0 0 auto;
     }
+
     @include govuk-media-query($from: desktop) {
       width: $toc-width;
     }

--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -1,0 +1,36 @@
+.app-subnav {
+  @include govuk-font(16);
+}
+
+.app-subnav__section {
+  margin: 0 0 govuk-spacing(4);
+  padding: 0;
+  list-style-type: none;
+}
+
+.app-subnav__link {
+  display: block;
+  padding: 8px govuk-spacing(6) 8px govuk-spacing(2);
+  border-left: 4px solid transparent;
+  text-decoration: none;
+
+  &:focus {
+    background: inherit;
+  }
+
+  &:hover,
+  &:active,
+  &:visited {
+    color: $govuk-link-colour;
+  }
+
+  &:hover {
+    border-left-color: $govuk-link-hover-colour;
+  }
+}
+
+.app-subnav__section-item--current .app-subnav__link {
+  border-left-color: $govuk-link-colour;
+  background: $app-light-grey;
+  font-weight: bold;
+}

--- a/application/scss/hmrc-design-system.scss
+++ b/application/scss/hmrc-design-system.scss
@@ -1,13 +1,13 @@
-//govuk-frontend dependencies* @import 'node_modules/govuk-frontend/settings/_media-queries.scss';
-@import 'node_modules/govuk-frontend/all.scss';
-@import 'node_modules/govuk-frontend/core/all.scss';
+//govuk-frontend dependencies
+@import 'node_modules/govuk-frontend/all';
 
 // HMRC Design System Base Styles template
-@import 'settings/colours.scss';
-@import 'settings/images.scss';
+@import 'settings/colours';
+@import 'settings/images';
 
 @import 'objects/width-container';
-@import 'components/_logo.scss';
-@import 'components/_hmrc-internal-header.scss';
-@import 'components/_pane.scss';
-@import 'components/_collapsible-subsections.scss'
+
+@import 'components/logo';
+@import 'components/hmrc-internal-header';
+@import 'components/pane';
+@import 'components/collapsible-subsections'

--- a/application/scss/hmrc-design-system.scss
+++ b/application/scss/hmrc-design-system.scss
@@ -10,4 +10,5 @@
 @import 'components/logo';
 @import 'components/hmrc-internal-header';
 @import 'components/pane';
+@import 'components/subnav';
 @import 'components/collapsible-subsections'

--- a/application/scss/settings/_colours.scss
+++ b/application/scss/settings/_colours.scss
@@ -1,2 +1,4 @@
 $hmrc-green: #009390;
 $black: #000000;
+$app-light-grey: #f8f8f8;
+$app-code-color: #dd1144;

--- a/application/templates/twoColumnPage.njk
+++ b/application/templates/twoColumnPage.njk
@@ -7,7 +7,17 @@
 
     <div class="app-pane__body">
       <div class="app-pane__subnav">
-        <h2 class="govuk-heading-m">HMRC Design Patterns</h2>
+        <h2 class="govuk-heading-m">
+          {% set designPatternsIndexPage = 'design-library/index.njk' %}
+
+          {% if filepath != designPatternsIndexPage %}
+          <a href="/design-library/">
+          {% endif %}
+          HMRC Design Patterns
+          {% if filepath != designPatternsIndexPage %}
+          </a>
+          {% endif %}
+        </h2>
         <nav class="app-subnav">
           <ul class="app-subnav__section">
           {% for item in navigation %}

--- a/application/templates/twoColumnPage.njk
+++ b/application/templates/twoColumnPage.njk
@@ -4,10 +4,26 @@
     <div class="app-pane__header">
       {%- include './partials/header.njk' -%}
     </div>
+
     <div class="app-pane__body">
       <div class="app-pane__subnav">
-        <nav><!-- Generate nav to go here --></nav>
+        <h2 class="govuk-heading-m">HMRC Design Patterns</h2>
+
+        <nav class="app-subnav">
+          <ul class="app-subnav__section">
+          {% for item in navigation %}
+            {% if item.section == 'design-library' %}
+            <li class="app-subnav__section-item">
+              <a class="app-subnav__link govuk-link" href="/{{ item.href }}">
+                {{item.text}}
+              </a>
+            </li>
+            {% endif %}
+          {% endfor %}
+          </ul>
+        </nav>
       </div>
+
       <div class="app-pane__content">
         <main role="main" class="app-content" id="main-content">
           <div class="govuk-grid-row">

--- a/application/templates/twoColumnPage.njk
+++ b/application/templates/twoColumnPage.njk
@@ -8,12 +8,13 @@
     <div class="app-pane__body">
       <div class="app-pane__subnav">
         <h2 class="govuk-heading-m">HMRC Design Patterns</h2>
-
         <nav class="app-subnav">
           <ul class="app-subnav__section">
           {% for item in navigation %}
+            {% set isActive = item.filepath === filepath %}
+
             {% if item.section == 'design-library' %}
-            <li class="app-subnav__section-item">
+            <li class="app-subnav__section-item{%if isActive%} app-subnav__section-item--current{% endif %}">
               <a class="app-subnav__link govuk-link" href="/{{ item.href }}">
                 {{item.text}}
               </a>

--- a/lib/__tests__/navigation.test.js
+++ b/lib/__tests__/navigation.test.js
@@ -1,0 +1,65 @@
+/* globals jest describe test expect */
+
+const navigation = require('../navigaiton')
+
+const metalsmithMock = {
+  metadata: jest.fn(() => ({}))
+}
+
+const doneMock = jest.fn()
+
+afterEach(jest.clearAllMocks)
+
+describe('Navigation metalsmith plugin', () => {
+  test('should add an object of unique patterns to metalsmith metadata', () => {
+    const files = {
+      'test/test-pattern/index.html': {
+        contents: Buffer.from('test pattern index page'),
+        mode: '0644',
+        stats: {},
+        filepath: 'test/test-pattern/index.njk'
+      },
+      'test/test-pattern/default/index.html': {
+        contents: Buffer.from('test default pattern'),
+        mode: '0644',
+        stats: {},
+        filepath: 'test/test-pattern/default/index.njk'
+      },
+      'test/test-pattern/variant/index.html': {
+        contents: Buffer.from('test pattern variant'),
+        mode: '0644',
+        stats: {},
+        filepath: 'test/test-pattern/variant/index.njk'
+      },
+      'another/testing/index.html': {
+        contents: Buffer.from('test different section'),
+        mode: '0644',
+        stats: {},
+        filepath: 'another/testing/index.njk'
+      }
+    }
+
+    const filesBefore = JSON.parse(JSON.stringify(files))
+
+    navigation()(files, metalsmithMock, doneMock)
+
+    const result = {
+      navigation: [
+        {
+          section: 'test',
+          text: 'Test pattern',
+          href: 'test/test-pattern'
+        },
+        {
+          section: 'another',
+          text: 'Testing',
+          href: 'another/testing'
+        }
+      ]
+    }
+
+    expect(JSON.stringify(filesBefore)).toEqual(JSON.stringify(files))
+    expect(metalsmithMock.metadata).toHaveReturnedWith(result)
+    expect(doneMock).toHaveBeenCalled()
+  })
+})

--- a/lib/__tests__/navigation.test.js
+++ b/lib/__tests__/navigation.test.js
@@ -48,12 +48,14 @@ describe('Navigation metalsmith plugin', () => {
         {
           section: 'test',
           text: 'Test pattern',
-          href: 'test/test-pattern'
+          href: 'test/test-pattern',
+          filepath: 'test/test-pattern/index.html'
         },
         {
           section: 'another',
           text: 'Testing',
-          href: 'another/testing'
+          href: 'another/testing',
+          filepath: 'another/testing/index.html'
         }
       ]
     }

--- a/lib/navigaiton.js
+++ b/lib/navigaiton.js
@@ -24,6 +24,7 @@ module.exports = function () {
       if (patternName && isUnique) {
         const item = {
           section,
+          filepath: file,
           text: patternName,
           href: [section, pattern].join('/')
         }

--- a/lib/navigaiton.js
+++ b/lib/navigaiton.js
@@ -1,0 +1,39 @@
+const path = require('path')
+
+const capitaliseFirstLetter = string => {
+  const [firstWord, ...otherWords] = string.split('-')
+  const [firstLetter, ...otherLetters] = firstWord
+
+  const capitalisedWord =
+    firstLetter.toUpperCase() +
+    otherLetters.join('').toLowerCase()
+
+  return [ capitalisedWord, otherWords ].join(' ').trim()
+}
+
+module.exports = function () {
+  return function (files, metalsmith, done) {
+    const navigation = []
+
+    for (const file in files) {
+      const { dir } = path.parse(file)
+      const [section, pattern] = dir.split('/')
+      const patternName = pattern && capitaliseFirstLetter(pattern)
+      const isUnique = !navigation.find(item => item.text === patternName)
+
+      if (patternName && isUnique) {
+        const item = {
+          section,
+          text: patternName,
+          href: [section, pattern].join('/')
+        }
+
+        navigation.push(item)
+      }
+    }
+
+    metalsmith.metadata().navigation = navigation
+
+    done()
+  }
+}

--- a/src/design-library/index.njk
+++ b/src/design-library/index.njk
@@ -1,3 +1,5 @@
+{%- extends 'twoColumnPage.njk' -%}
+
 {%- block content -%}
-    <h1 class="govuk-heading-xl">Design library</h1>
+    <h1 class="govuk-heading-xl">HMRC Design Patterns</h1>
 {%- endblock -%}

--- a/tasks/gulp/build.js
+++ b/tasks/gulp/build.js
@@ -6,6 +6,7 @@ const inPlace = require('metalsmith-in-place')
 const debug = require('metalsmith-debug')
 const metalsmithPath = require('metalsmith-path')
 const ignore = require('metalsmith-ignore')
+const navigation = require('../../lib/navigaiton')
 const pathFromRoot = require('./util').pathFromRoot
 
 const projectRoot = pathFromRoot()
@@ -26,11 +27,11 @@ gulp.task('compile', (done) => {
     .source('./src')
     .destination('./dist')
     .clean(true)
-    .use(debug())
     .use(metalsmithPath({
       property: 'filepath',
       extensions: ['.njk', '.html']
     }))
+    .use(navigation())
     .use(inPlace({
       engine: 'nunjucks',
       pattern: pattern,
@@ -40,6 +41,7 @@ gulp.task('compile', (done) => {
         filters: { is_array: filters.isArray, dirname: filters.getDirectoryFromFilepath }
       }
     }))
+    .use(debug())
     .build((err) => {
       if (err) throw err
       done()


### PR DESCRIPTION
This is a first pass at generating navigation from directory names. 

**Notes**

Each nav item's text is generated by capitalising the first letter of the directory name.

Based on requirements from the prototype and our previous design system, the ability to control the nav title will be required. I've deemed that out of scope for this PR in order to keep the workload smaller and more focussed.

We might also need to think of a way to manage the nav title, but was keen to avoid processing frontmatter and/or a separate navigation config file in order to get the nav added in its simplest form.

Similarly, the layout of the actual page needs addressing separately to this PR.

## Before 

![image](https://user-images.githubusercontent.com/1752124/50376634-e94e2700-060f-11e9-80f4-00804b633726.png)

## After

![image](https://user-images.githubusercontent.com/1752124/50770072-41c72a80-1286-11e9-907f-997280ea2753.png)

![image](https://user-images.githubusercontent.com/1752124/50770100-5efbf900-1286-11e9-8425-ee917e376ebf.png)
