### PR TITLE
SDT-1002 Make index page cards same height

### DIFF
--- a/application/scss/components/_card.scss
+++ b/application/scss/components/_card.scss
@@ -7,7 +7,6 @@
   @include govuk-media-query(desktop) {
     min-height: 168px;
   }
-
 }
 
 .app-card__heading {

--- a/application/scss/components/_card.scss
+++ b/application/scss/components/_card.scss
@@ -4,6 +4,10 @@
   display: block;
   padding: 20px;
   margin-bottom: 20px;
+  @include govuk-media-query(desktop) {
+    min-height: 168px;
+  }
+
 }
 
 .app-card__heading {


### PR DESCRIPTION
## Implementation
In the prototype the cards on the index page are set to have a minimum height on _desktop_ resolutions of 160px. However the natural size for the largest card is 165 px. I've given the cards a minimum height of 168px. It looked nicer with a bit extra and it makes for a number that can be divided more easily if needed. 

## Before
![screenshot from 2019-01-25 09-42-54](https://user-images.githubusercontent.com/234825/51737878-a4d9ff00-2085-11e9-8baa-3aadf88a81d1.png)

## After
![screenshot from 2019-01-25 09-41-58](https://user-images.githubusercontent.com/234825/51737896-b3281b00-2085-11e9-947a-3b1544484d9f.png)
