### PR TITLE
Displaying Welsh examples.

### DIFF
--- a/application/assets/javascripts/components/language-switch-example.js
+++ b/application/assets/javascripts/components/language-switch-example.js
@@ -12,6 +12,9 @@ function LanguageSwitchExample ($module) {
   this.$switches = this.$module.querySelectorAll('.app-example__language-switch')
   this.$iframe = this.$module.querySelector('[data-module~="app-example-frame"]')
   this.currentClassName = 'app-example__language-switch--current'
+  this.getLanguageClass = function (lang) {
+    return ['app-example__language-switch--', lang, '-activated'].join('')
+  }
 }
 
 LanguageSwitchExample.prototype.init = function () {
@@ -33,12 +36,12 @@ LanguageSwitchExample.prototype.handleClick = function (event) {
   var $target = event.target
   nodeListForEach(this.$module.querySelectorAll('.' + this.currentClassName), function ($option) {
     $option.classList.remove(self.currentClassName)
+    $option.querySelector('a').focus()
   })
   this.$iframe.setAttribute('src', $target.getAttribute('href'))
-  $target.classList.add(this.currentClassName)
-  this.$module.classList.remove('en-mode')
-  this.$module.classList.remove('cy-mode')
-  this.$module.classList.add($target.getAttribute('data-lang') + '-mode')
+  $target.parentNode.classList.add(this.currentClassName)
+  this.$module.classList.remove(this.getLanguageClass('en'), this.getLanguageClass('cy'))
+  this.$module.classList.add(this.getLanguageClass($target.getAttribute('data-lang')))
 }
 
 export default LanguageSwitchExample

--- a/application/assets/javascripts/components/language-switch-example.js
+++ b/application/assets/javascripts/components/language-switch-example.js
@@ -1,0 +1,41 @@
+// Taken from https://github.com/alphagov/govuk-design-system/blob/29b9cf8c30ac1514d16fc97adaf15100e5040f7d/src/javascripts/components/tabs.js
+
+import 'govuk-frontend/vendor/polyfills/Function/prototype/bind'
+import 'govuk-frontend/vendor/polyfills/Element/prototype/classList'
+import 'govuk-frontend/vendor/polyfills/Event'
+import common from 'govuk-frontend/common'
+
+var nodeListForEach = common.nodeListForEach
+
+function LanguageSwitchExample ($module) {
+  this.$module = $module
+  this.$switches = this.$module.querySelectorAll('.app-example__language-switch')
+  this.$iframe = this.$module.querySelector('[data-module~="app-example-frame"]')
+  this.currentClassName = 'app-example__language-switch--current'
+}
+
+LanguageSwitchExample.prototype.init = function () {
+  var self = this
+
+  if (!this.$module) {
+    return
+  }
+
+  nodeListForEach(this.$switches, function ($this) {
+    $this.addEventListener('click', self.handleClick.bind(self))
+  })
+}
+
+// Close current container on click
+LanguageSwitchExample.prototype.handleClick = function (event) {
+  var self = this
+  event.preventDefault()
+  var $target = event.target
+  nodeListForEach(this.$module.querySelectorAll('.' + this.currentClassName), function ($option) {
+    $option.classList.remove(self.currentClassName)
+  })
+  this.$iframe.setAttribute('href', $target.getAttribute('href'))
+  $target.classList.add(this.currentClassName)
+}
+
+export default LanguageSwitchExample

--- a/application/assets/javascripts/components/language-switch-example.js
+++ b/application/assets/javascripts/components/language-switch-example.js
@@ -34,8 +34,11 @@ LanguageSwitchExample.prototype.handleClick = function (event) {
   nodeListForEach(this.$module.querySelectorAll('.' + this.currentClassName), function ($option) {
     $option.classList.remove(self.currentClassName)
   })
-  this.$iframe.setAttribute('href', $target.getAttribute('href'))
+  this.$iframe.setAttribute('src', $target.getAttribute('href'))
   $target.classList.add(this.currentClassName)
+  this.$module.classList.remove('en-mode')
+  this.$module.classList.remove('cy-mode')
+  this.$module.classList.add($target.getAttribute('data-lang') + '-mode')
 }
 
 export default LanguageSwitchExample

--- a/application/assets/javascripts/hmrc-design-system.js
+++ b/application/assets/javascripts/hmrc-design-system.js
@@ -1,10 +1,17 @@
 import common from 'govuk-frontend/common'
 import AppTabs from './components/tabs.js'
+import LanguageSwitchExample from './components/language-switch-example'
 
 var nodeListForEach = common.nodeListForEach
 
 // Initialise tabs
-var $tabs = document.querySelectorAll('[data-module="app-tabs"]')
+var $tabs = document.querySelectorAll('[data-module~="app-tabs"]')
 nodeListForEach($tabs, function ($tabs) {
   new AppTabs($tabs).init()
+})
+
+// Initialise language switch
+var $languageSwitchExamples = document.querySelectorAll('[data-module~="app-language-switch-example"]')
+nodeListForEach($languageSwitchExamples, function ($example) {
+  new LanguageSwitchExample($example).init()
 })

--- a/application/scss/components/_example.scss
+++ b/application/scss/components/_example.scss
@@ -52,11 +52,11 @@
   display: none;
 }
 
-.en-mode .cy-only {
+.app-example__language-switch--en-activated .app-example__language-switch--cy-only-content {
   display: none
 }
 
-.cy-mode .en-only {
+.app-example__language-switch--cy-activated .app-example__language-switch--en-only-content {
   display: none
 }
 

--- a/application/scss/components/_example.scss
+++ b/application/scss/components/_example.scss
@@ -52,6 +52,14 @@
   display: none;
 }
 
+.en-mode .cy-only {
+  display: none
+}
+
+.cy-mode .en-only {
+  display: none
+}
+
 .app-example__frame {
   display: block;
   width: 100%;

--- a/application/scss/components/_example.scss
+++ b/application/scss/components/_example.scss
@@ -26,11 +26,10 @@
   }
 }
 
-.app-example__new-window {
+.app-example__link {
   position: absolute;
   z-index: 1;
   top: 0;
-  left: 0;
   padding: 5px govuk-spacing(2);
   @include govuk-font(14);
   background: govuk-colour("grey-3");
@@ -39,6 +38,18 @@
     color: $govuk-link-colour;
     text-decoration: none;
   }
+}
+
+.app-example__new-window {
+  left: 0;
+}
+
+.app-example__language-switch {
+  right: 0;
+}
+
+.app-example__language-switch--current {
+  display: none;
 }
 
 .app-example__frame {

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -4,9 +4,12 @@
   {% set examplePath = "src" + exampleURL + "index.njk" %}
   {% set exampleId = "example-" + exampleRef %}
   {% if params.welsh %}
-    {% set welshExampleURL = "/design-library/" + params.item + "/" + params.welsh + "/" %}
+    {% set welshExampleRef = params.welsh | default("default") %}
+    {% set welshExampleURL = "/design-library/" + params.item + "/" + welshExampleRef + "/" %}
+    {% set welshExamplePath = "src" + welshExampleURL + "index.njk" %}
+    {% set welshExampleURL = "/design-library/" + params.item + "/" + welshExampleRef + "/" %}
   {% endif %}
-  <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs app-language-switch-example">
+  <div class="app-example-wrapper en-mode" id="{{ exampleId }}" data-module="app-tabs app-language-switch-example">
     <div class="app-example app-example--tabs">
       <span class="app-example__link app-example__new-window">
         <a href="{{ exampleURL }}" target="_blank">
@@ -14,13 +17,13 @@
         </a>
       </span>
       <span class="app-example__link app-example__language-switch app-example__language-switch--current">
-          <a href="{{  exampleURL }}" target="_blank">
+          <a href="{{ exampleURL }}" data-lang="en" target="_blank">
             Display in English
           </a>
         </span>
       {% if welshExampleURL %}
         <span class="app-example__link app-example__language-switch">
-          <a href="{{  welshExampleURL }}" target="_blank">
+          <a href="{{ welshExampleURL }}" data-lang="cy" target="_blank">
             Display in Welsh
           </a>
         </span>
@@ -29,26 +32,38 @@
               src="{{ exampleURL }}" frameBorder="0"></iframe>
     </div>
 
-    <span id="options-{{ exampleId }}"></span>
-    <ul class="app-tabs" role="tablist">
-      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab"
-        aria-controls="{{ exampleId }}-html"
-        data-track="tab-html">HTML</a></li>
-      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab"
-        aria-controls="{{ exampleId }}-nunjucks"
-        data-track="tab-nunjucks">Nunjucks</a></li>
-    </ul>
+    <div class="example-{{ exampleId }}-lang example-{{ exampleId }}-lang--en ">
+      <span id="options-{{ exampleId }}"></span>
+      <ul class="app-tabs" role="tablist">
+        <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab"
+                                                                        aria-controls="{{ exampleId }}-html"
+                                                                        data-track="tab-html">HTML</a></li>
+        <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab"
+                                                                        aria-controls="{{ exampleId }}-nunjucks"
+                                                                        data-track="tab-nunjucks">Nunjucks</a></li>
+      </ul>
 
-    <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
-      <pre data-module="app-copy"><code class="hljs html">
-        {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
-      </code></pre>
-    </div>
-
-    <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
-        <pre data-module="app-copy"><code class="hljs js">
-          {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
+      <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
+        <pre data-module="app-copy" class="en-only"><code class="hljs html">
+          {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
         </code></pre>
+        {% if welshExamplePath %}
+          <pre data-module="app-copy" class="cy-only"><code class="hljs html">
+          {{- getHTMLCode(welshExamplePath) | highlight('html') | safe -}}
+        </code></pre>
+        {% endif %}
+      </div>
+
+      <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
+          <pre data-module="app-copy" class="en-only"><code class="hljs js">
+            {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
+          </code></pre>
+        {% if welshExamplePath %}
+          <pre data-module="app-copy" class="cy-only"><code class="hljs js">
+            {{- getNunjucksCode(welshExamplePath) | highlight('js') | safe -}}
+          </code></pre>
+        {% endif %}
+      </div>
     </div>
   </div>
 {% endmacro %}

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -11,13 +11,18 @@
           Open this example in a new window
         </a>
       </span>
-      <iframe data-module="app-example-frame" class="app-example__frame app-example__frame--resizable" src="{{ exampleURL }}" frameBorder="0"></iframe>
+      <iframe data-module="app-example-frame" class="app-example__frame app-example__frame--resizable"
+              src="{{ exampleURL }}" frameBorder="0"></iframe>
     </div>
 
     <span id="options-{{ exampleId }}"></span>
     <ul class="app-tabs" role="tablist">
-      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
-      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
+      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab"
+        aria-controls="{{ exampleId }}-html"
+        data-track="tab-html">HTML</a></li>
+      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab"
+        aria-controls="{{ exampleId }}-nunjucks"
+        data-track="tab-nunjucks">Nunjucks</a></li>
     </ul>
 
     <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
@@ -26,10 +31,10 @@
       </code></pre>
     </div>
 
-      <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
+    <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
         <pre data-module="app-copy"><code class="hljs js">
           {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
         </code></pre>
-      </div>
+    </div>
   </div>
 {% endmacro %}

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -18,12 +18,12 @@
       </span>
       {% if welshExampleURL %}
         <span class="app-example__link app-example__language-switch app-example__language-switch--current">
-          <a href="{{ exampleURL }}" data-lang="en" target="_blank">
+          <a href="{{ exampleURL }}" data-lang="en" target="_blank" data-track="lang-switch-en">
             Display in English
           </a>
         </span>
         <span class="app-example__link app-example__language-switch js-enabled">
-          <a href="{{ welshExampleURL }}" data-lang="cy" target="_blank">
+          <a href="{{ welshExampleURL }}" data-lang="cy" target="_blank" data-track="lang-switch-cy">
             Display in Welsh
           </a>
         </span>

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -9,20 +9,20 @@
     {% set welshExamplePath = "src" + welshExampleURL + "index.njk" %}
     {% set welshExampleURL = "/design-library/" + params.item + "/" + welshExampleRef + "/" %}
   {% endif %}
-  <div class="app-example-wrapper en-mode" id="{{ exampleId }}" data-module="app-tabs app-language-switch-example">
+  <div class="app-example-wrapper app-example__language-switch--en-activated" id="{{ exampleId }}" data-module="app-tabs app-language-switch-example">
     <div class="app-example app-example--tabs">
       <span class="app-example__link app-example__new-window">
         <a href="{{ exampleURL }}" target="_blank">
           Open this example in a new window
         </a>
       </span>
-      <span class="app-example__link app-example__language-switch app-example__language-switch--current">
+      {% if welshExampleURL %}
+        <span class="app-example__link app-example__language-switch app-example__language-switch--current">
           <a href="{{ exampleURL }}" data-lang="en" target="_blank">
             Display in English
           </a>
         </span>
-      {% if welshExampleURL %}
-        <span class="app-example__link app-example__language-switch">
+        <span class="app-example__link app-example__language-switch js-enabled">
           <a href="{{ welshExampleURL }}" data-lang="cy" target="_blank">
             Display in Welsh
           </a>
@@ -44,22 +44,22 @@
       </ul>
 
       <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
-        <pre data-module="app-copy" class="en-only"><code class="hljs html">
+        <pre data-module="app-copy" class="app-example__language-switch--en-only-content"><code class="hljs html">
           {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
         </code></pre>
         {% if welshExamplePath %}
-          <pre data-module="app-copy" class="cy-only"><code class="hljs html">
+          <pre data-module="app-copy" class="app-example__language-switch--cy-only-content"><code class="hljs html">
           {{- getHTMLCode(welshExamplePath) | highlight('html') | safe -}}
         </code></pre>
         {% endif %}
       </div>
 
       <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
-          <pre data-module="app-copy" class="en-only"><code class="hljs js">
+          <pre data-module="app-copy" class="app-example__language-switch--en-only-content"><code class="hljs js">
             {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
           </code></pre>
         {% if welshExamplePath %}
-          <pre data-module="app-copy" class="cy-only"><code class="hljs js">
+          <pre data-module="app-copy" class="app-example__language-switch--cy-only-content"><code class="hljs js">
             {{- getNunjucksCode(welshExamplePath) | highlight('js') | safe -}}
           </code></pre>
         {% endif %}

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -1,70 +1,38 @@
 {% macro example(params) %}
-  {% set exampleRoot = "src/design-library/" + params.item + "/" + params.example + "/" %}
-  {% set exampleURL = "/design-library/" + params.item + "/" + params.example + "/index.html" %}
-  {% set exampleId = params.id | default("example-" + params.example) %}
-  {% set exampleTitle = params.title %}
-  {% set multipleTabs = params.html and params.nunjucks %}
-
-  {% if params.customCode %}
-    {% set examplePath = exampleRoot + "code.njk" %}
-  {% else %}
-    {% set examplePath = exampleRoot + "index.njk" %}
-  {% endif %}
-
-  {% if params.open %}
-    {% set exampleId = exampleId + '-open' %}
-  {% endif %}
+  {% set exampleRef = params.example | default("default") %}
+  {% set exampleURL = "/design-library/" + params.item + "/" + exampleRef + "/" %}
+  {% set examplePath = "src" + exampleURL + "index.njk" %}
+  {% set exampleId = "example-" + exampleRef %}
 
   <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
-    <div class="app-example {{ "app-example--tabs" if params.html or params.nunjucks }}">
+    <div class="app-example app-example--tabs">
       <span class="app-example__new-window">
         <a href="{{ exampleURL }}" target="_blank">
-          Open this
-          <span class="govuk-visually-hidden"> "{{ exampleTitle }}" </span>
-          example in a new window
+          Open this example in a new window
         </a>
       </span>
-      <iframe title="{{ exampleTitle }}" data-module="app-example-frame" class="app-example__frame app-example__frame--resizable{% if params.size %} app-example__frame--{{ params.size }}{% endif %}" src="{{ exampleURL }}" frameBorder="0"></iframe>
+      <iframe data-module="app-example-frame" class="app-example__frame app-example__frame--resizable" src="{{ exampleURL }}" frameBorder="0"></iframe>
     </div>
 
-    {%- if (multipleTabs) %}
     <span id="options-{{ exampleId }}"></span>
     <ul class="app-tabs" role="tablist">
-      <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
+      <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></li>
       <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
     </ul>
-    {% elif not (params.hideTab) %}
-    {% set tabType = "html" if params.html else ("nunjucks" if params.nunjucks ) %}
-    <ul class="app-tabs" role="tablist">
-      <li class="app-tabs__item js-tabs__item{{ " js-tabs__item--open" if (params.open) }}" role="presentation">
-        <a href="#{{ exampleId }}-{{ tabType }}" role="tab" aria-controls="{{ exampleId }}-{{ tabType }}" data-track="tab-{{ tabType }}">{{ "HTML" if params.html else ("Nunjucks" if params.nunjucks )}}</a>
-      </li>
-    </ul>
-    {% endif %}
 
-    {%- if (params.html) %}
-    {%- if (multipleTabs) or (not params.hideTab) %}
-    <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
-    {% endif %}
-    <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-html" role="tabpanel">
+    <div class="app-tabs__heading js-tabs__heading js-tabs__heading--open"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
+    <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
       <pre data-module="app-copy"><code class="hljs html">
         {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
       </code></pre>
     </div>
-    {% endif %}
 
-    {%- if (params.nunjucks) %}
-      {%- if (multipleTabs) %}
       <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
-      {% elif not (params.hideTab) %}
-      <div class="app-tabs__heading js-tabs__heading{{ " js-tabs__heading--open" if (params.open) }}"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
-      {% endif %}
 
-      <div class="app-tabs__container js-tabs__container{{ " js-tabs__container--no-tabs" if (params.hideTab) }}" id="{{ exampleId }}-nunjucks" role="tabpanel">
+      <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
         <pre data-module="app-copy"><code class="hljs js">
           {{- getNunjucksCode(examplePath) | highlight('js') | safe -}}
         </code></pre>
       </div>
-    {% endif %}
   </div>
 {% endmacro %}

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -20,14 +20,11 @@
       <li class="app-tabs__item js-tabs__item" role="presentation"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></li>
     </ul>
 
-    <div class="app-tabs__heading js-tabs__heading js-tabs__heading--open"><a href="#{{ exampleId }}-html" role="tab" aria-controls="{{ exampleId }}-html" data-track="tab-html">HTML</a></div>
     <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
       <pre data-module="app-copy"><code class="hljs html">
         {{- getHTMLCode(examplePath) | highlight('html') | safe -}}
       </code></pre>
     </div>
-
-      <div class="app-tabs__heading js-tabs__heading"><a href="#{{ exampleId }}-nunjucks" role="tab" aria-controls="{{ exampleId }}-nunjucks" data-track="tab-nunjucks">Nunjucks</a></div>
 
       <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
         <pre data-module="app-copy"><code class="hljs js">

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -5,7 +5,6 @@
   {% set exampleId = "example-" + exampleRef %}
   {% if params.welsh %}
     {% set welshExampleRef = params.welsh | default("default") %}
-    {% set welshExampleURL = "/design-library/" + params.item + "/" + welshExampleRef + "/" %}
     {% set welshExamplePath = "src" + welshExampleURL + "index.njk" %}
     {% set welshExampleURL = "/design-library/" + params.item + "/" + welshExampleRef + "/" %}
   {% endif %}

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -3,14 +3,28 @@
   {% set exampleURL = "/design-library/" + params.item + "/" + exampleRef + "/" %}
   {% set examplePath = "src" + exampleURL + "index.njk" %}
   {% set exampleId = "example-" + exampleRef %}
-
-  <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs">
+  {% if params.welsh %}
+    {% set welshExampleURL = "/design-library/" + params.item + "/" + params.welsh + "/" %}
+  {% endif %}
+  <div class="app-example-wrapper" id="{{ exampleId }}" data-module="app-tabs app-language-switch-example">
     <div class="app-example app-example--tabs">
-      <span class="app-example__new-window">
+      <span class="app-example__link app-example__new-window">
         <a href="{{ exampleURL }}" target="_blank">
           Open this example in a new window
         </a>
       </span>
+      <span class="app-example__link app-example__language-switch app-example__language-switch--current">
+          <a href="{{  exampleURL }}" target="_blank">
+            Display in English
+          </a>
+        </span>
+      {% if welshExampleURL %}
+        <span class="app-example__link app-example__language-switch">
+          <a href="{{  welshExampleURL }}" target="_blank">
+            Display in Welsh
+          </a>
+        </span>
+      {% endif %}
       <iframe data-module="app-example-frame" class="app-example__frame app-example__frame--resizable"
               src="{{ exampleURL }}" frameBorder="0"></iframe>
     </div>

--- a/src/design-library/new-tab-link/index.njk
+++ b/src/design-library/new-tab-link/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: twoColumnPage.njk
 title: Open links in a new window or tab
+menuText: Open in a new window
 ---
 
 {% from "_example.njk" import example %}

--- a/src/design-library/new-tab-link/index.njk
+++ b/src/design-library/new-tab-link/index.njk
@@ -1,7 +1,6 @@
 ---
 layout: twoColumnPage.njk
 title: Open links in a new window or tab
-menuText: Open in a new window
 ---
 
 {% from "_example.njk" import example %}
@@ -56,21 +55,14 @@ menuText: Open in a new window
 </div>
 
 {{ example({
-  item: "new-tab-link",
-  example: "default",
-  html: true,
-  nunjucks: true,
-  open: false
+  item: "new-tab-link"
 }) }}
 
 <p class="govuk-body">This component is also available in welsh:</p>
 
 {{ example({
   item: "new-tab-link",
-  example: "welsh",
-  html: true,
-  nunjucks: true,
-  open: false
+  example: "welsh"
 }) }}
 <h2 id="research" class="govuk-heading-l">Research</h2>
 

--- a/src/design-library/new-tab-link/index.njk
+++ b/src/design-library/new-tab-link/index.njk
@@ -55,15 +55,10 @@ title: Open links in a new window or tab
 </div>
 
 {{ example({
-  item: "new-tab-link"
-}) }}
-
-<p class="govuk-body">This component is also available in welsh:</p>
-
-{{ example({
   item: "new-tab-link",
-  example: "welsh"
+  welsh: "welsh"
 }) }}
+
 <h2 id="research" class="govuk-heading-l">Research</h2>
 
 <p class="govuk-body">We need more research. If you have used open links in a new window or tab, get in touch to share

--- a/src/design-library/notification-badge/index.njk
+++ b/src/design-library/notification-badge/index.njk
@@ -32,10 +32,7 @@ layout: twoColumnPage.njk
 </div>
 
 {{ example({
-  item: "notification-badge",
-  example: "default",
-  html: true,
-  nunjucks: true
+  item: "notification-badge"
 }) }}
 
 <p class="govuk-body">If the number is more than 99, display ‘99+’.</p>
@@ -44,9 +41,7 @@ layout: twoColumnPage.njk
 
 {{ example({
   item: "notification-badge",
-  example: "no-items",
-  html: true,
-  nunjucks: true
+  example: "no-items"
 }) }}
 
 <h2 class="govuk-heading-l" id="research">Research</h2>

--- a/src/design-library/notification-badge/index.njk
+++ b/src/design-library/notification-badge/index.njk
@@ -35,8 +35,7 @@ layout: twoColumnPage.njk
   item: "notification-badge",
   example: "default",
   html: true,
-  nunjucks: true,
-  open: false
+  nunjucks: true
 }) }}
 
 <p class="govuk-body">If the number is more than 99, display ‘99+’.</p>
@@ -47,8 +46,7 @@ layout: twoColumnPage.njk
   item: "notification-badge",
   example: "no-items",
   html: true,
-  nunjucks: true,
-  open: false
+  nunjucks: true
 }) }}
 
 <h2 class="govuk-heading-l" id="research">Research</h2>


### PR DESCRIPTION
HMRC produce patterns and components with English and Welsh translations.  This feature allows the design-system user to see how to implement in English and Welsh.

It supports keyboard interactions and contains tracking config.

Example usage:

```
{{ example({
  item: "open-in-a-new-window",
  welsh: "welsh"
}) }}
```

The `welsh` example sits alongside the `default` and any others.