### PR TITLE
Splitting assets task out into multiple tasks

### DIFF
--- a/tasks/gulp/copy-assets.js
+++ b/tasks/gulp/copy-assets.js
@@ -10,14 +10,20 @@ const assetPaths = [
   '!' + pathFromRoot('application', 'assets', 'javascripts', 'hmrc-design-system.js')
 ]
 
-gulp.task('copy-assets', () => {
+gulp.task('copy-assets', ['copy-assets:local', 'copy-assets:remote'])
+
+gulp.task('copy-assets:local', () => {
   const assets = gulp.src(assetPaths)
     .pipe(gulp.dest(pathFromRoot('dist', 'assets')))
 
   const jquery = gulp.src(pathFromRoot('node_modules', 'jquery', 'dist', '*'))
     .pipe(gulp.dest(pathFromRoot('dist', 'assets', 'javascripts', 'vendor', 'jquery')))
 
-  const collapsible = remoteSrc([
+  return merge(assets, jquery)
+})
+
+gulp.task('copy-assets:remote', () =>{
+  return remoteSrc([
     'collapsible.js',
     'collapsible_collection.js',
     'current_location.js'
@@ -25,8 +31,6 @@ gulp.task('copy-assets', () => {
     base: 'https://raw.githubusercontent.com/alphagov/manuals-frontend/master/app/assets/javascripts/modules/'
   })
     .pipe(gulp.dest(pathFromRoot('dist', 'assets', 'javascripts', 'vendor', 'govuk')))
-
-  return merge(assets, jquery, collapsible)
 })
 
 gulp.task('copy-assets:watch', () => {


### PR DESCRIPTION
This way when the remote fails it is more obvious what the problem is.

Previously there were three pipes being merged, all of them fail silently.  It would be good to add a timeout to this remote one too (or question why it's not an npm/bower dependency instead) but for now I think the project is slightly improved by identifying whether the problem is with the local or remote assets.

I encountered this problem while on a terribly slow connection therefore it's hard to reproduce (without using network toys).  It's as though this timed out both quickly and silently.

This will allow us to spot more easily if the `copy-assets:remote` task starts but doesn't stop - if that continues happening then a better/proper fix would be needed, that may include not relying on remote sources (as this would allow offline builds).