### PR TITLE
PLATUI-117: Update of hmrc-frontend dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## [1.1.2] - 2019-08-22
+
+### Removed
+- A redundant 'TODO' comment [0a51262](0a51262734b95ff5cdf12aafeda93288e7feb4fa)
+
+### Updated
+- `hmrc-frontend` to version 1.0.4 and removed now redundant Javascrit hack to prevent collapse of menu in account header example [746abd0](746abd0aae8073f44e1f67d6eba9c66e245a68eb)
+
 ## [1.1.1] - 2019-08-20
 
 ### Added

--- a/application/templates/layout-example.njk
+++ b/application/templates/layout-example.njk
@@ -16,22 +16,5 @@
     {%- endblock -%}
   </body>
 
-  <script>
-    // This prevents the account dropdown from closing and triggering
-    // an infinite loop on the auto iframe resize
-    // Can be removed on completion of https://jira.tools.tax.service.gov.uk/browse/PLATUI-117
-    function getWindowHeight () {
-     return Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
-    }
-
-    var initialHeight = getWindowHeight()
-
-    window.addEventListener('resize', function (event) {
-      if (getWindowHeight() !== initialHeight) {
-        event.stopImmediatePropagation()
-        initialHeight = getWindowHeight()
-      }
-    });
-  </script>
   <script src="/assets/javascripts/hmrc-design-system.js"></script>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmrc/design-system",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8433,9 +8433,9 @@
       "dev": true
     },
     "hmrc-frontend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-1.0.3.tgz",
-      "integrity": "sha512-mLAXmwVyDLBunSrqTBBU2gRqTr6dCVZSL6Bxr/Hp78G4AmpiBfCRsoYn3oOMAJW6w2wyuYPQ5UWnIfJCgyK0TA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-1.0.4.tgz",
+      "integrity": "sha512-xVl2j7KfVizKsOrzZHhC8gWF9FpsXuWg+ZDygI1o1UaN1qaTtUgiuCJsDb3p/TVYP2fE+WgdJCR5U8Fm0sj86w==",
       "requires": {
         "govuk-frontend": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmrc/design-system",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "Static site generator for the HMRC Design System",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/hmrc/design-system#readme",
   "dependencies": {
     "govuk-frontend": "^3.0.0",
-    "hmrc-frontend": "^1.0.3"
+    "hmrc-frontend": "^1.0.4"
   },
   "devDependencies": {
     "autoprefixer": "^9.6.1",

--- a/tasks/gulp/sass.js
+++ b/tasks/gulp/sass.js
@@ -33,9 +33,6 @@ gulp.task('scss:watch', (done) => {
 
 gulp.task('scss:hmrc-design-system', (done) => {
   // TODO: compile an Old IE version of our local css
-  // TODO: Given that we are importing hrmc- and govuk-frontend into this file do we need to be
-  // copying over the stylesheet assets in the copy-assets task? I have removed the references to these in the layout
-  // files and seen no obvious ill-effects
   // Also pertains to PLATUI-161: https://jira.tools.tax.service.gov.uk/browse/PLATUI-161 -->
   gulp.src('./application/scss/hmrc-design-system.scss')
     .pipe(header('$govuk-assets-path: "/extension-assets/govuk-frontend/govuk/assets/";\n'))


### PR DESCRIPTION
![](https://brent.cloud/grabs/S02E05/gif/66vCjcYQaCOB.gif)

* Updated `hmrc-frontend` to 1.0.4
* Removed now redundant JS hack to stop account menu collapsing in account header example
* Removed an erroneous 'TODO'