### PR TITLE
Fixed missing example tabs on mobile and dodgy menu styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [1.7.1] - 2019-09-30
+
+### Fixed
+- Full width sub-menu and show HTML / Nunjucks tabs in mobile view [2b42104](2b42104f4326dab8d26683e93b59c3eee87c8db6)
+
 ## [1.7.0] - 2019-09-24
 
 ### Added

--- a/application/scss/components/_notification-banner.scss
+++ b/application/scss/components/_notification-banner.scss
@@ -1,7 +1,11 @@
 .notification-banner-wrapper {
   color: govuk-colour("white");
   background-color: $govuk-link-colour;
-  padding:15px 0 0 0;
+  padding:15px 0 5px 0;
+
+  @include govuk-media-query($from: tablet) {
+    padding-bottom: 0;
+  }
 
   p.govuk-body, a.govuk-link {
     color: govuk-colour("white");

--- a/application/scss/components/_pane.scss
+++ b/application/scss/components/_pane.scss
@@ -35,17 +35,12 @@
   }
 
   .app-pane__subnav {
-    border-right: 1px solid $govuk-border-colour;
     padding: govuk-spacing(4) 0;
 
-    @include govuk-media-query($from: tablet) {
+    @include govuk-media-query($from: desktop) {
       padding: govuk-spacing(6) 0;
-      width: $toc-width-tablet;
       border-right: 1px solid $govuk-border-colour;
       flex: 0 0 auto;
-    }
-
-    @include govuk-media-query($from: desktop) {
       width: $toc-width;
     }
   }

--- a/application/scss/components/_tabs.scss
+++ b/application/scss/components/_tabs.scss
@@ -8,10 +8,6 @@
   list-style-type: none;
   border: 1px solid $govuk-border-colour;
 
-  @include govuk-media-query($until: desktop) {
-    display: none;
-  }
-
   .app-prose-scope & { // A specific selector to reset .app-prose-scope ul
     margin-bottom: 0;
     padding: 0;


### PR DESCRIPTION
![](https://media.giphy.com/media/hkiLcRr7zoPe0/giphy.gif)

* Make submenu on mobile full width and remove border-right
* Show HTML / Nunjucks tabs on mobile
* Bumped patch version and updated changelog