### PR TITLE
Remove development status for account menu component

### DIFF
--- a/src/hmrc-design-patterns/account-menu/index.njk
+++ b/src/hmrc-design-patterns/account-menu/index.njk
@@ -1,6 +1,5 @@
 ---
 title: Account menu
-status: development
 layout: twoColumnPage.njk
 ---
 


### PR DESCRIPTION
This is not in development, nor is it experimental. Lots of teams
use it.