### PR TITLE
Fixes typo in code examples for page titles

### DIFF
--- a/src/hmrc-design-patterns/page-title/index.njk
+++ b/src/hmrc-design-patterns/page-title/index.njk
@@ -41,7 +41,7 @@ title: Page title
 
   {{
     codeSnippet({
-      code: '<title>Do you live in the UK? – Your details – Manage your tax credits – GOV.UK<titl>',
+      code: '<title>Do you live in the UK? – Your details – Manage your tax credits – GOV.UK<title>',
       canCopy: true
     })
   }}
@@ -52,7 +52,7 @@ title: Page title
 
   {{
     codeSnippet({
-      code: '<title>Error: Do you live in the UK? – Your details – Manage your tax credits – GOV.UK<titl>',
+      code: '<title>Error: Do you live in the UK? – Your details – Manage your tax credits – GOV.UK<title>',
       canCopy: true
     })
   }}


### PR DESCRIPTION
The closing `</title>` tag was misspelled.