### PR TITLE
Archived patterns

### DIFF
--- a/application/templates/partials/_phaseBanner.njk
+++ b/application/templates/partials/_phaseBanner.njk
@@ -1,7 +1,10 @@
 {% macro phaseBanner(params) %}
   {% set status = params.status %}
   {% if params.status %}
-    {% set defaultStatusText %}This is currently {{ status }} because <a class="govuk-link" href="#research">more research</a> is needed.{% endset %}
+    {% if params.status != 'archived' %}
+      {% set defaultStatusText %}This is currently {{ status }} because <a class="govuk-link" href="#research">more research</a> is needed.{% endset %}
+    {% endif %}
+
     {% set statusText = params.statusText or defaultStatusText %}
     <div class="govuk-!-padding-bottom-8 hmrc-phase-banner">
       <strong class="govuk-tag govuk-!-margin-top-4 govuk-!-margin-bottom-2">

--- a/lib/__tests__/navigation.test.js
+++ b/lib/__tests__/navigation.test.js
@@ -67,6 +67,13 @@ describe('Navigation metalsmith plugin', () => {
         stats: {},
         filepath: 'section1/test-pattern/with-additional-segment/index.njk'
       },
+      'section1/archived-test-pattern/index.html': {
+        contents: Buffer.from('test pattern with archived status'),
+        mode: '0644',
+        stats: {},
+        filepath: 'section1/archived-test-pattern/index.njk',
+        status: 'archived'
+      },
       'section1/development-test-pattern/index.html': {
         contents: Buffer.from('test pattern with development status'),
         mode: '0644',

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -46,10 +46,12 @@ module.exports = function () {
       const isUnique = !navSection || !navSection.items.find(item => item.href === href)
 
       const isNotInDevelopment = status != 'development'
+      const isNotArchived = status != 'archived'
       const shouldAppearInMenu = text
         && isUnique
         && isComponentIndex
         && isNotInDevelopment
+        && isNotArchived
         && placement !== 'none'
 
       if (shouldAppearInMenu) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmrc/design-system",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8263,7 +8263,6 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-
       "dev": true
     },
     "lodash._basecopy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5152,9 +5152,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.9.1.tgz",
-      "integrity": "sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg=="
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.1.tgz",
+      "integrity": "sha512-2x6B0jV1pTx4Alxm3MY222BfIQpg+ctUYaUzyBjmNkisWKdRmCP61oyFXklZgqXMjvaN+oo3rRbAALrxFTeeig=="
     },
     "graceful-fs": {
       "version": "4.2.0",
@@ -5721,11 +5721,11 @@
       "dev": true
     },
     "hmrc-frontend": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-1.17.0.tgz",
-      "integrity": "sha512-sCcAzVIx6pNxnx1kxn2uW49qc767jn2wTDM3PSoYix+NNZZwD7eYJ+JxJnmMJ3ht0HTMkmn1Kqcql/dU4cPmUw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-1.21.0.tgz",
+      "integrity": "sha512-PeoOa3MNgx62LONGdcd2e0LaBYQ8j21CbHmvQHHxpyFaRnnJiREXej0Xrut5AUxILUcXEJ+KZbGiHVOtGlXBjQ==",
       "requires": {
-        "govuk-frontend": "^3.7.0"
+        "govuk-frontend": "^3.9.1"
       }
     },
     "homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/hmrc/design-system#readme",
   "dependencies": {
-    "govuk-frontend": "^3.9.1",
-    "hmrc-frontend": "^1.17.0"
+    "govuk-frontend": "^3.10.1",
+    "hmrc-frontend": "^1.21.0"
   },
   "devDependencies": {
     "autoprefixer": "^9.6.5",

--- a/src/hmrc-design-patterns/hmrc-design-patterns-archive/index.njk
+++ b/src/hmrc-design-patterns/hmrc-design-patterns-archive/index.njk
@@ -1,0 +1,40 @@
+---
+title: Archived patterns
+menuText: Archived patterns
+navigationPlacement: secondary
+layout: twoColumnPage.njk
+---
+
+{% block content %}
+
+<p class="govuk-body">Patterns in the HMRC design system maybe archived where:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+<li> similar guidance is published in the GOV.UK design system </li>
+<li> the pattern is upstreamed and published in the GOV.UK design system </li>
+<li> the pattern or guidance has been deprecated  </li>
+
+</ul>
+
+
+
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+
+<h3 class="govuk-heading-m">Open links in a new window or tab</h2>
+
+<p class="govuk-body"> The pattern was archived on the 5th of october 2020</p>
+
+<p class="govuk-body">
+The HMRC version of this pattern has been removed because GOV.UK has published an updated version of the pattern in the GOV.UK design system.
+
+</p>
+
+<p class="govuk-body">
+<a class="govuk-link" href="https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab">View the new guidance on opening links in a new tab</a>.
+</p>
+
+
+
+{% endblock %}

--- a/src/hmrc-design-patterns/hmrc-design-patterns-archive/index.njk
+++ b/src/hmrc-design-patterns/hmrc-design-patterns-archive/index.njk
@@ -7,34 +7,19 @@ layout: twoColumnPage.njk
 
 {% block content %}
 
-<p class="govuk-body">Patterns in the HMRC design system may be archived where:</p>
+<p class="govuk-body">HMRC patterns are archived when:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-<li> similar guidance is published in the GOV.UK design system </li>
-<li> the pattern is upstreamed and published in the GOV.UK design system </li>
-<li> the pattern or guidance has been deprecated  </li>
-
+  <li>GDS updates the GOV.UK Design System to include similar guidance</li>
+  <li>GDS includes the pattern in the GOV.UK Design System</li>
+  <li>we do not recommend you use the pattern</li>
 </ul>
 
-
-
-
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-
-<h3 class="govuk-heading-m">Open links in a new window or tab</h2>
-
-<p class="govuk-body"> The pattern was archived on the 5th of october 2020</p>
-
-<p class="govuk-body">
-The HMRC version of this pattern has been removed because GOV.UK has published an updated version of the pattern in the GOV.UK design system.
-
-</p>
-
-<p class="govuk-body">
-<a class="govuk-link" href="https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab">View the new guidance on opening links in a new tab</a>.
-</p>
-
-
+<div class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <h2 class="govuk-heading-m">Open links in a new window or tab</h2>
+  <p class="govuk-body">This pattern was archived on 5 October 2020.</p>
+  <p class="govuk-body">HMRC removed this guidance because GDS updated its guidance on this style in the GOV.UK Design System.</p>
+  <p class="govuk-body">Read about <a class="govuk-link" href="https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab">how to style links that open in a new tab in the GOV.UK Design System</a>.</p>
+</div>
 
 {% endblock %}

--- a/src/hmrc-design-patterns/hmrc-design-patterns-archive/index.njk
+++ b/src/hmrc-design-patterns/hmrc-design-patterns-archive/index.njk
@@ -7,7 +7,7 @@ layout: twoColumnPage.njk
 
 {% block content %}
 
-<p class="govuk-body">Patterns in the HMRC design system maybe archived where:</p>
+<p class="govuk-body">Patterns in the HMRC design system may be archived where:</p>
 
 <ul class="govuk-list govuk-list--bullet">
 <li> similar guidance is published in the GOV.UK design system </li>

--- a/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index-archived.njk
+++ b/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index-archived.njk
@@ -1,0 +1,77 @@
+---
+title: Open links in a new window or tab archived
+menuText: Open in a new window or tab
+layout: twoColumnPage.njk
+---
+
+{% from "_example.njk" import example %}
+
+{% block content %}
+
+<p class="govuk-body">This pattern lets the user open links in a new window or tab.</p>
+
+<h2 class="govuk-heading-l" id="when-to-use">When to use</h2>
+
+<p class="govuk-body">First, design your service so that links open in the same window or tab and test with users.
+  Research shows that some users struggle to get back to a service because the back button does not work in the new
+  window or tab.</p>
+
+<p class="govuk-body">Only use this pattern if opening a link in a new window or tab meets a user need or is necessary
+  to use the service. This could be because:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>the link is to a document in a different format, like a PDF</li>
+  <li>the link is to guidance that cannot be inside the service</li>
+  <li>the user would lose their details if they left the service</li>
+  <li>the user needs to go to another site or service to get information</li>
+</ul>
+
+<h2 class="govuk-heading-l" id="when-not-to-use">When not to use</h2>
+
+<p class="govuk-body">Do not use if opening a link in a new window or tab:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>does not meet a user need</li>
+  <li>leads to more than one window or tab open within the same service</li>
+  <li>stops the user completing their task</li>
+</ul>
+
+<h2 class="govuk-heading-l" id="how-it-works">How it works</h2>
+
+<p class="govuk-body">Always put ‘(opens in a new window or tab)’ inside the link text content.</p>
+
+<p class="govuk-body">In the code include:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>target=&quot;_blank&quot;</code> to open in a new window or tab</li>
+  <li><code>rel=&quot;noopener noreferrer&quot;</code> to reduce security risks for some browsers</li>
+</ul>
+
+<p class="govuk-body">Do not use any icons in place of the words. See ‘<a class="govuk-link"
+                                                                          href="https://designnotes.blog.gov.uk/2016/11/28/removing-the-external-link-icon-from-gov-uk/">Removing
+    the external link icon from GOV.UK</a>’.</p>
+
+<div class="govuk-inset-text">
+  You need HMRC Frontend to use this pattern – <a class="govuk-link" href="/hmrc-design-patterns/install-hmrc-frontend-in-your-prototype/">find out how to
+    install HMRC Frontend</a>. If you use the HMRC Nunjucks macro, you must copy and paste the entire macro in to your
+  code.
+</div>
+
+{{
+  example({
+    item: "open-links-in-a-new-window-or-tab",
+    description: 'Open in a new window',
+    example: 'example',
+    welsh: 'example-welsh'
+  })
+}}
+
+<h2 id="research" class="govuk-heading-l">Research</h2>
+
+<p class="govuk-body">We need more research. If you have used open links in a new window or tab, get in touch to share
+  your research findings.</p>
+
+<p class="govuk-body"><a class="govuk-link" href="https://github.com/hmrc/design-patterns/issues/141">Discuss open links
+    in a new window or tab on GitHub</a></p>
+
+{% endblock %}

--- a/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index-archived.njk
+++ b/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index-archived.njk
@@ -1,5 +1,6 @@
 ---
 title: Open links in a new window or tab archived
+status: archived
 menuText: Open in a new window or tab
 layout: twoColumnPage.njk
 ---

--- a/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index.njk
+++ b/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index.njk
@@ -1,5 +1,6 @@
 ---
 title: Open links in a new window or tab
+status: archived
 menuText: Open in a new window or tab
 layout: twoColumnPage.njk
 ---
@@ -18,7 +19,5 @@ The HMRC version of this pattern has been removed because GOV.UK has published a
 <p class="govuk-body">
 <a class="govuk-link" href="https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab">View the new guidance on opening links in a new tab</a>.
 </p>
-
-
 
 {% endblock %}

--- a/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index.njk
+++ b/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index.njk
@@ -9,15 +9,8 @@ layout: twoColumnPage.njk
 
 {% block content %}
 
-<p class="govuk-body"> The pattern was archived on the 5th of october 2020.</p>
-
-<p class="govuk-body">
-The HMRC version of this pattern has been removed because GOV.UK has published an updated version of the pattern in the GOV.UK design system.
-
-</p>
-
-<p class="govuk-body">
-<a class="govuk-link" href="https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab">View the new guidance on opening links in a new tab</a>.
-</p>
+<p class="govuk-body">This pattern was archived on 5 October 2020.</p>
+<p class="govuk-body">HMRC removed this guidance because GDS updated its guidance on this style in the GOV.UK Design System.</p>
+<p class="govuk-body">Read about <a class="govuk-link" href="https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab">how to style links that open in a new tab in the GOV.UK Design System</a>.</p>
 
 {% endblock %}

--- a/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index.njk
+++ b/src/hmrc-design-patterns/open-links-in-a-new-window-or-tab/index.njk
@@ -8,70 +8,17 @@ layout: twoColumnPage.njk
 
 {% block content %}
 
-<p class="govuk-body">This pattern lets the user open links in a new window or tab.</p>
+<p class="govuk-body"> The pattern was archived on the 5th of october 2020.</p>
 
-<h2 class="govuk-heading-l" id="when-to-use">When to use</h2>
+<p class="govuk-body">
+The HMRC version of this pattern has been removed because GOV.UK has published an updated version of the pattern in the GOV.UK design system.
 
-<p class="govuk-body">First, design your service so that links open in the same window or tab and test with users.
-  Research shows that some users struggle to get back to a service because the back button does not work in the new
-  window or tab.</p>
+</p>
 
-<p class="govuk-body">Only use this pattern if opening a link in a new window or tab meets a user need or is necessary
-  to use the service. This could be because:</p>
+<p class="govuk-body">
+<a class="govuk-link" href="https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab">View the new guidance on opening links in a new tab</a>.
+</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>the link is to a document in a different format, like a PDF</li>
-  <li>the link is to guidance that cannot be inside the service</li>
-  <li>the user would lose their details if they left the service</li>
-  <li>the user needs to go to another site or service to get information</li>
-</ul>
 
-<h2 class="govuk-heading-l" id="when-not-to-use">When not to use</h2>
-
-<p class="govuk-body">Do not use if opening a link in a new window or tab:</p>
-
-<ul class="govuk-list govuk-list--bullet">
-  <li>does not meet a user need</li>
-  <li>leads to more than one window or tab open within the same service</li>
-  <li>stops the user completing their task</li>
-</ul>
-
-<h2 class="govuk-heading-l" id="how-it-works">How it works</h2>
-
-<p class="govuk-body">Always put ‘(opens in a new window or tab)’ inside the link text content.</p>
-
-<p class="govuk-body">In the code include:</p>
-
-<ul class="govuk-list govuk-list--bullet">
-  <li><code>target=&quot;_blank&quot;</code> to open in a new window or tab</li>
-  <li><code>rel=&quot;noopener noreferrer&quot;</code> to reduce security risks for some browsers</li>
-</ul>
-
-<p class="govuk-body">Do not use any icons in place of the words. See ‘<a class="govuk-link"
-                                                                          href="https://designnotes.blog.gov.uk/2016/11/28/removing-the-external-link-icon-from-gov-uk/">Removing
-    the external link icon from GOV.UK</a>’.</p>
-
-<div class="govuk-inset-text">
-  You need HMRC Frontend to use this pattern – <a class="govuk-link" href="/hmrc-design-patterns/install-hmrc-frontend-in-your-prototype/">find out how to
-    install HMRC Frontend</a>. If you use the HMRC Nunjucks macro, you must copy and paste the entire macro in to your
-  code.
-</div>
-
-{{
-  example({
-    item: "open-links-in-a-new-window-or-tab",
-    description: 'Open in a new window',
-    example: 'example',
-    welsh: 'example-welsh'
-  })
-}}
-
-<h2 id="research" class="govuk-heading-l">Research</h2>
-
-<p class="govuk-body">We need more research. If you have used open links in a new window or tab, get in touch to share
-  your research findings.</p>
-
-<p class="govuk-body"><a class="govuk-link" href="https://github.com/hmrc/design-patterns/issues/141">Discuss open links
-    in a new window or tab on GitHub</a></p>
 
 {% endblock %}


### PR DESCRIPTION
This commit adds an archived patterns section to the HMRC Design System.
Patterns that have a status of archived are removed from the menu but are accessible if the link is known.

Further work will be done to move archived patterns into their own folder and the content shared between the pattern and the archived section. 