### PR TITLE
Changed focus style to be the same as gov.uk

### DIFF
--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -97,16 +97,6 @@
   padding: govuk-spacing(3) 0;
   text-decoration: none;
 
-  &:focus {
-    background: inherit;
-  }
-
-  &:hover,
-  &:active,
-  &:visited {
-    color: $govuk-link-colour;
-  }
-
   @include govuk-media-query(desktop) {
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) govuk-spacing(2);
     border-left: 4px solid transparent;


### PR DESCRIPTION
The focus states for the main navigation of the HMRC Design Patterns are unclear as it can be difficult to know what's focused especially when it's next to an active (or current) link as shown:
![Screen Shot 2021-04-09 at 15 53 08-fullpage](https://user-images.githubusercontent.com/10420657/114048877-d912f200-9882-11eb-8688-274e5f3e68cd.png)
This PR makes the focus state more similar to default gov.uk links and helps remove the ambiguity:
![Screen Shot 2021-04-09 at 15 58 59-fullpage](https://user-images.githubusercontent.com/10420657/114150035-79b0f280-9913-11eb-8ed7-a65e6a6ae830.png)
