### PR TITLE
Dr 1128 custom code tabs

### DIFF
--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -14,6 +14,12 @@
     {% set welshExamplePath = "src" + welshExampleURL + "index.njk" %}
   {% endif %}
 
+  {% if params.markdown %}
+    {% set markdownExampleRef = params.markdown %}
+    {% set markdownExampleURL = "/examples/" + params.item + "/" + markdownExampleRef + "/" %}
+    {% set markdownExamplePath = "src" + markdownExampleURL + "index.md" %}
+  {% endif %}
+
   <div class="app-example-wrapper app-example__language-switch--en-activated" id="{{ exampleId }}" data-module="app-tabs app-language-switch-example">
 
     <div class="app-example app-example--tabs">
@@ -43,17 +49,29 @@
       <div class="example-{{ exampleId }}-lang example-{{ exampleId }}-lang--en ">
         <span id="options-{{ exampleId }}"></span>
         <ul class="app-tabs" role="tablist">
-          <li class="app-tabs__item js-tabs__item" role="presentation">
-            <a href="#{{ exampleId }}-html" role="tab"
-              aria-controls="{{ exampleId }}-html"
-              data-track="tab-html" title="Display {{description}} example as HTML">HTML</a>
-          </li>
-          {% if not params.htmlOnly %}
+          {% if not params.markdownOnly %}
             <li class="app-tabs__item js-tabs__item" role="presentation">
-              <a href="#{{ exampleId }}-nunjucks" role="tab"
-                aria-controls="{{ exampleId }}-nunjucks"
-                data-track="tab-nunjucks" title="Display {{description}} example as Nunjucks">Nunjucks</a>
+              <a href="#{{ exampleId }}-html" role="tab"
+                aria-controls="{{ exampleId }}-html"
+                data-track="tab-html" title="Display {{description}} example as HTML">HTML</a>
             </li>
+            {% if not params.htmlOnly %}
+              <li class="app-tabs__item js-tabs__item" role="presentation">
+                <a href="#{{ exampleId }}-nunjucks" role="tab"
+                  aria-controls="{{ exampleId }}-nunjucks"
+                  data-track="tab-nunjucks" title="Display {{description}} example as Nunjucks">Nunjucks</a>
+              </li>
+            {% endif %}
+          {% endif %}
+
+          {% if not params.htmlOnly %}
+            {% if params.markdown %}
+              <li class="app-tabs__item js-tabs__item" role="presentation">
+                <a href="#{{ exampleId }}-markdown" role="tab"
+                  aria-controls="{{ exampleId }}-markdown"
+                  data-track="tab-markdown" title="Display {{description}} example as Markdown">Markdown</a>
+              </li>
+            {% endif %}
           {% endif %}
         </ul>
 
@@ -90,6 +108,27 @@
                 <pre class="app-example__language-switch--cy-only-content">
                   <code class="hljs js">
                     {{- getNunjucksCode(welshExamplePath) | highlight('js') | safe -}}
+                  </code>
+                </pre>
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
+
+        {% if params.markdown %}
+          <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-markdown" role="tabpanel">
+            {{ copyContents() }}
+            <div data-module="app-copy">
+              <pre class="app-example__language-switch--en-only-content">
+                <code class="hljs md">
+                  {{- getHTMLCode(markdownExamplePath) | highlight('md') | safe -}}
+                </code>
+              </pre>
+
+              {% if welshExamplePath %}
+                <pre class="app-example__language-switch--cy-only-content">
+                  <code class="hljs md">
+                    {{- getHTMLCode(welshExamplePath) | highlight('md') | safe -}}
                   </code>
                 </pre>
               {% endif %}

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -124,14 +124,6 @@
                   {{- getHTMLCode(markdownExamplePath) | highlight('md') | safe -}}
                 </code>
               </pre>
-
-              {% if welshExamplePath %}
-                <pre class="app-example__language-switch--cy-only-content">
-                  <code class="hljs md">
-                    {{- getHTMLCode(welshExamplePath) | highlight('md') | safe -}}
-                  </code>
-                </pre>
-              {% endif %}
             </div>
           </div>
         {% endif %}

--- a/src/hmrc-design-patterns/currency-input/index.njk
+++ b/src/hmrc-design-patterns/currency-input/index.njk
@@ -42,7 +42,7 @@ layout: twoColumnPage.njk
     example({
       item: 'currency-input',
       example: 'pounds',
-        welsh: 'pounds-welsh',
+      welsh: 'pounds-welsh',
       description: 'Pounds only'
     })
   }}


### PR DESCRIPTION
This PR enables the ability to show markdown files in the examples tabs.

To add a Markdown example:
1. Add a folder to the applicable examples folder e.g. `examples/button/button-markdown`

2. Create a file in that folder called `index.md` with the markdown example in it

2. In the Example, provide the location of the folder e.g.
```nunjucks
{{
    example({
      item: 'button',
      example: 'button',
      welsh: 'button-welsh',
      description: 'Button example',
      markdown: 'button-markdown'
    })
}}
```
4. You can optionally provide an extra argument if you only want to show the markdown tab e.g. 
```nunjucks
{{
    example({
      item: 'button',
      example: 'button',
      welsh: 'button-welsh',
      description: 'Button example',
      markdown: 'button-markdown',
      markdownOnly: true
    })
}}
```

Currently the Welsh tab pane won't work but will be followed up in a future PR. 