### PR TITLE
PLATUI-1339: update chrome extension config

### DIFF
--- a/application/assets/config/chromeExtension.json
+++ b/application/assets/config/chromeExtension.json
@@ -1,7 +1,7 @@
 {
   "version": "01-2020",
-  "manifestUrl": "https://raw.githubusercontent.com/hmrc/play-frontend-govuk-examples/master/src/test/resources/manifest.json",
-  "examplesRootUrl": "https://raw.githubusercontent.com/hmrc/play-frontend-govuk-examples/master/src/test/",
+  "manifestUrl": "https://raw.githubusercontent.com/hmrc/play-frontend-govuk-examples/main/src/test/resources/manifest.json",
+  "examplesRootUrl": "https://raw.githubusercontent.com/hmrc/play-frontend-govuk-examples/main/src/test/",
   "vendorComponentPathPrefix": "hmrc/",
   "govukComponentPathPrefix": "",
   "features": {


### PR DESCRIPTION
hmrc/play-frontend-govuk-examples has changed it's default branch to
main and this updates the config the extension uses to find examples.