### PR TITLE
Adding 3 new 'form' pattern pages

### DIFF
--- a/src/hmrc-content-guide/forms-check/index.njk
+++ b/src/hmrc-content-guide/forms-check/index.njk
@@ -1,0 +1,36 @@
+---
+title: Forms > Check which document type to use
+menuText: Forms > Check which document type to use
+layout: twoColumnPage.njk
+---
+
+<p class="govuk-body">
+You will normally use a <a href="/hmrc-content-guide/forms-detailed-guide/" class="govuk-link">detailed guide</a> when: 
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+<li>the form is an alternative way to complete a task (and the main way to complete the task is covered in a detailed guide)</li>
+<li>when we want the user to read guidance about the task before they complete the form</li>
+<li>the form is the way a user completes the task covered in the detailed guide</li>
+</ul>
+
+<p class="govuk-body">
+You will normally use a <a href="/hmrc-content-guide/forms-publication/" class="govuk-link">publication</a> when:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+<li>the form could be used and linked to from multiple pieces of guidance</li>
+<li>the form may be used multiple times by the same user and that the priority is getting access to the form, rather than any guidance that may sit around it</li>
+</ul>
+
+<p class="govuk-body">
+Do not use a publication if you need the users to read any information on the page before they access the form.
+</p>
+
+<p class="govuk-body">
+You will need to decide on the best option depending on the customer journey, insight and design principles. 
+</p>
+
+<p class="govuk-body">
+But in most cases a detailed guide will give you more flexibility to create a better experience for users. For example, <a href="https://www.gov.uk/guidance/apply-to-access-customs-handling-of-import-and-export-freight-c1800" class="govuk-link">Apply to access Customs Handling of Import and Export Freight (C1800)</a>.
+</p>

--- a/src/hmrc-content-guide/forms-detailed-guide/index.njk
+++ b/src/hmrc-content-guide/forms-detailed-guide/index.njk
@@ -1,0 +1,118 @@
+---
+title: Forms > Using a detailed guide
+menuText: Forms > Using a detailed guide
+layout: twoColumnPage.njk
+---
+{% from "_codeSnippet.njk" import codeSnippet %}
+
+<h2 class="govuk-heading-l">All forms</h2>
+
+<p class="govuk-body">
+The following forms will be accessible:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+<li>a gForm (<a href="https://tax.service.gov.uk" class="govuk-link">https://tax.service.gov.uk</a>)</li>
+<li>in Open Document Format</li>
+</ul>
+
+<p class="govuk-body">
+For all other forms, you should include the following accessibility statement after the form:
+</p>
+
+  {{
+    codeSnippet({
+      code: 'Read the [accessibility statement for HMRC forms](https://www.gov.uk/guidance/accessibility-statement-for-hmrc-interactive-forms).',
+      canCopy: true
+    })
+  }}
+
+<p class="govuk-body">
+If the form is not translated into Welsh, always include:
+</p>
+
+  {{
+    codeSnippet({
+      code: 'Email HMRC to [ask for form name in Welsh (Cymraeg)](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/welsh-language-helplines#email).',
+      canCopy: true
+    })
+  }}
+
+<h3 class="govuk-heading-m">Forms that are attachments</h3>
+
+<p class="govuk-body">
+If you’re going to attach a file, you must use the publication box !@n markdown.
+</p>
+
+<p class="govuk-body">
+Do not tick ‘Attachment is accessible’ – as the attachment must always have the ‘not suitable for assistive technology’ callout.
+</p>
+
+<h4 class="govuk-heading-s">Interactive PDFs</h4>
+
+<p class="govuk-body">
+Markdown:
+</p>
+
+  {{
+    codeSnippet({
+      code: '## How to complete the form
+
+You need to:
+
+s1. Download and save the form on your computer.
+
+s2. Open it using the [the latest free version of Adobe Reader](http://get.adobe.com/uk/reader/).
+
+s3. Complete it on-screen.
+
+!@n
+
+Read the [accessibility statement for HMRC forms](https://www.gov.uk/guidance/accessibility-statement-for-hmrc-interactive-forms).
+
+^It may not work it you try to open it in your internet browser. If the form does not open, then contact the Online Services helpdesks for more help.',
+      canCopy: true
+    })
+  }}
+
+<h3 class="govuk-heading-m">Forms that are links</h3>
+
+<h4 class="govuk-heading-s">gForms</h4>
+
+<p class="govuk-body">
+gForms are hosted on <a href="https://tax.service.gov.uk" class="govuk-link">https://tax.service.gov.uk</a>. Depending on design of the detailed guide, use either an inline link or a green button.
+</p>
+
+<h4 class="govuk-heading-s">Print and post forms</h4>
+
+<p class="govuk-body">
+These will be hosted on <a href="https://public-online.hmrc.gov.uk/lc/content/" class="govuk-link">https://public-online.hmrc.gov.uk/lc/content/</a>.
+</p>
+
+<p class="govuk-body">
+Markdown:
+</p>
+
+  {{
+    codeSnippet({
+      code: 's1. You need to open and complete this form online. As you cannot save your progress, you may want to get all your information together before you start.
+
+s2. Fill in [name of form](LINK).
+
+s3. Print and post it to HMRC, using the postal address shown on the form.
+
+^This file may not be suitable if you use assistive technology – such as a screen reader. If you need a more accessible format email <different.format@hmrc.gov.uk> and tell us what format you need. It will help if you tell us what assistive technology you use. Read the [accessibility statement for HMRC forms](https://www.gov.uk/guidance/accessibility-statement-for-hmrc-interactive-forms).',
+      canCopy: true
+    })
+  }}
+
+<p class="govuk-body">
+You may need to include the following:
+</p>
+
+  {{
+    codeSnippet({
+      code: 'If the form does not open, then [contact the Online Services helpdesks for more help](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/online-services-helpdesk).',
+      canCopy: true
+    })
+  }}

--- a/src/hmrc-content-guide/forms-publication/index.njk
+++ b/src/hmrc-content-guide/forms-publication/index.njk
@@ -1,0 +1,133 @@
+---
+title: Forms > Using a publication
+menuText: Forms > Using a publication
+layout: twoColumnPage.njk
+---
+{% from "_codeSnippet.njk" import codeSnippet %}
+{% from "_example.njk" import example %}
+
+<h2 class="govuk-heading-l">Title</h2>
+
+<p class="govuk-body">
+Decide if the title should focus on the action a user needs to take or the name of the form. This will depend on how users will find and navigate to the form. 
+</p>
+
+<p class="govuk-body">
+Do not include the form number.
+</p>
+
+<h2 class="govuk-heading-l">Summary</h2>
+
+<p class="govuk-body">
+If there’s a form number you should include it. For example:
+</p>
+
+<p class="govuk-body">
+'Register your business for VAT if you’re distance selling into Northern Ireland using form VAT1A'
+</p>
+
+<h3 class="govuk-heading-m">Documents</h3>
+
+<p class="govuk-body">
+If there’s a form number, include it in brackets at the end of the document title. For example:
+</p>
+
+<p class="govuk-body">
+‘Application for registration – distance selling (VAT1A)’
+</p>
+
+<p class="govuk-body">
+Unless the form is a gForm (<a href="https://tax.service.gov.uk" class="govuk-link">https://tax.service.gov.uk</a>) or in Open Document Format, you must include an external link attachment directly below the form in the document list:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+<li>External attachment title: Read the Accessibility statement for HMRC forms</li>
+<li>Link: <a href="https://www.gov.uk/guidance/accessibility-statement-for-hmrc-interactive-forms" class="govuk-link">https://www.gov.uk/guidance/accessibility-statement-for-hmrc-interactive-forms</a></li>
+</ul>
+
+<p class="govuk-body">
+If you have more than one form, the attachment only needs to be included after the first form in the list.
+</p>
+
+<h3 class="govuk-heading-m">Details</h3>
+
+<p class="govuk-body">
+You should include a short summary of when to use the form including any links to any detailed guidance a user must read.
+</p>
+
+<h4 class="govuk-heading-s">Welsh</h4>
+
+<p class="govuk-body">
+If the form is not translated into Welsh, include:
+</p>
+
+  {{
+    codeSnippet({
+      code: 'Email HMRC to [ask for form name in Welsh (Cymraeg)](https://www.gov.uk/government/organisations/hm-revenue-customs/contact/welsh-language-helplines#email).',
+      canCopy: true
+    })
+  }}
+
+<h4 class="govuk-heading-s">Print and post forms</h4>
+
+<p class="govuk-body">
+If the form is a print and post form, include:
+</p>
+
+  {{
+    codeSnippet({
+      code: '## Before you start
+
+Make sure [your browser is up to date](https://www.gov.uk/help/browsers).
+
+You’ll need to fill in the form fully before you can print it. You cannot save a partly completed form so we suggest you gather all your information together before you begin to fill it in.',
+      canCopy: true
+    })
+  }}
+
+<h4 class="govuk-heading-s">PDF forms that can be completed on-screen</h4>
+
+<p class="govuk-body">
+If the form is in PDF format, include: 
+</p>
+
+  {{
+    codeSnippet({
+      code: '## Before you start 
+
+This form is interactive (one that you complete on screen) and you must use [Adobe Reader](https://get.adobe.com/reader/?loc=uk ) to complete it.
+
+[Contact the Online Services helpdesk](https://www.tax.service.gov.uk/information/helpdesk) if you have problems opening or saving the form.',
+      canCopy: true
+    })
+  }}
+
+<h4 class="govuk-heading-s">Forms in Open Document Format (ODF)</h4>
+
+<p class="govuk-body">
+If the form is in ODF format, include:
+</p>
+
+  {{
+    codeSnippet({
+      code: '## Before you start 
+      
+You’ll need software that can open an Open Document Format (ODF) file, such as a recent version of Microsoft Office or [the free LibreOffice](https://www.libreoffice.org/).',
+      canCopy: true
+    })
+  }}
+
+<h4 class="govuk-heading-s">Address</h4>
+
+<p class="govuk-body">
+If the address to send the form is not included on the form itself, include:
+</p>
+
+  {{
+    codeSnippet({
+      code: '## Where to send the form
+$A
+$A',
+      canCopy: true
+    })
+  }}


### PR DESCRIPTION
Unlike the rest of this section these pages haven't previously been on Confluence. A little out of the ordinary as they're 3 linked pages that they feel need to be separate (but are open to other suggestions).

The drafts from GOV.UK showed markup rather than examples. I'm in two minds whether to use the codesnippet boxes or example boxes for the two pages with examples. For lots of small markup examples with no styling the example boxes make the pages longer and add an extra click for users. Also some of the examples are more suited to being shown as markup. But they are a clearer way to show the text.