### PR TITLE
Updating hmrc-frontend to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5624,11 +5624,18 @@
       "dev": true
     },
     "hmrc-frontend": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-2.1.0.tgz",
-      "integrity": "sha512-zOQDfK1prvaFuxte1Z/GQBJNlGLOiZmPOpisF9CEYxvZ3KCSpRxwK7imRKWEFdocPUUJiV8rb3MmziglIlJGZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-3.2.0.tgz",
+      "integrity": "sha512-qUy/S3uNHL5cLGBtHldfG6pRWD4qSWl6Zn17MKZd7Gq/MLVFqLB949rKis+l3hHoMjvuYLgNUu7xQFe4B8BGPA==",
       "requires": {
-        "govuk-frontend": "^3.13.0"
+        "govuk-frontend": "^3.14.0"
+      },
+      "dependencies": {
+        "govuk-frontend": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
+          "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+        }
       }
     },
     "homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/hmrc/design-system#readme",
   "dependencies": {
     "govuk-frontend": "3.13.0",
-    "hmrc-frontend": "^2.1.0"
+    "hmrc-frontend": "^3.2.0"
   },
   "devDependencies": {
     "autoprefixer": "^9.6.5",


### PR DESCRIPTION
Updating the version number in design-system to reflect the newest hmrc-frontend version. 