### PR TITLE
Desktop navigation disappears when mobile navigation is opened

### DIFF
--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -6,9 +6,6 @@
 
 .app-subnav-toggle + input:checked + .app-pane__subnav {
   display: block;
-  @include govuk-media-query(desktop) {
-    display: none;
-  }
 }
 
 .app-subnav-toggle {


### PR DESCRIPTION
Without this media query, you are able to reduce to mobile size, open the mobile menu, then return to desktop size without the nav disappearing