### PR TITLE
Update hmrc-frontend to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5753,9 +5753,9 @@
       "dev": true
     },
     "hmrc-frontend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-4.1.0.tgz",
-      "integrity": "sha512-naf+1FQ2sUHe+2KgnOB8Fgh27UGW4eabw7cFM1Q29NbdMdyzOPSFIo2LVIsNCDnEKfbKoABaxIV+oSLArMQ3hQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-4.1.1.tgz",
+      "integrity": "sha512-g+q4bZUVykg1D2reFA5ijQFw3u/CWrYLERg3lZ08q+ovEUmpb0wanMMMS+0piJTGqbHHUn+0ktmtS4d5do2Z0A==",
       "requires": {
         "govuk-frontend": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/hmrc/design-system#readme",
   "dependencies": {
     "govuk-frontend": "4.0.0",
-    "hmrc-frontend": "^4.1.0"
+    "hmrc-frontend": "^4.1.1"
   },
   "devDependencies": {
     "autoprefixer": "^9.6.5",


### PR DESCRIPTION
Made a patch on hmrc-frontend [here](https://github.com/hmrc/hmrc-frontend/commit/f4b9e2a7de667ab8d555f0fdb0958a5b0e9c70ca), pulling it through to the design system