### PR TITLE
Amending invalid IDs in HMRC Content Style Guide

### DIFF
--- a/src/hmrc-content-style-guide/index.njk
+++ b/src/hmrc-content-style-guide/index.njk
@@ -222,7 +222,7 @@ is now due’.</p>
 <h3 class='govuk-heading-s' id='full-stops'>full stops</h3>
 <p class='govuk-body'>Only use a full stop to end a complete sentence. Do not use them to end headings,
 sub-headings or form labels.</p>
-<h3 class='govuk-heading-s' id='funding notification form'>Funding Notification form</h3>
+<h3 class='govuk-heading-s' id='funding-notification-form'>Funding Notification form</h3>
 <p class='govuk-body'>Upper case ‘F’ and ‘N’, lower case ‘f’ for ‘form’.</p>"
         }
       },
@@ -273,7 +273,7 @@ next to them. For example ‘work-related’, ‘self-employed’ and ‘tax-fre
           html: "
 <h3 class='govuk-heading-s' id='income-bearing-asset'>income-bearing asset</h3>
 <p class='govuk-body'>1 hyphen.</p>
-<h3 class='govuk-heading-s' id='interest-bearing securities'>interest-bearing securities</h3>
+<h3 class='govuk-heading-s' id='interest-bearing-securities'>interest-bearing securities</h3>
 <p class='govuk-body'>1 hyphen.</p>
 <h3 class='govuk-heading-s' id='in-year-payment'>in-year payment</h3>
 <p class='govuk-body'>1 hyphen.</p>"
@@ -377,7 +377,7 @@ payable in monthly instalments’.</p>
 <p class='govuk-body'>Initial caps.</p>
 <h3 class='govuk-heading-s' id='payroll-accreditation-process'>Payroll Accreditation process</h3>
 <p class='govuk-body'>Upper case ‘P’ and ‘A’, lower case ‘p’ for ‘process’.</p>
-<h3 class='govuk-heading-s' id='payroll giving'>Payroll Giving</h3>
+<h3 class='govuk-heading-s' id='payroll-giving'>Payroll Giving</h3>
 <p class='govuk-body'>Initial caps.</p>
 <h3 class='govuk-heading-s' id='penalty'>penalty</h3>
 <p class='govuk-body'>Use ‘penalty’ for the sake of consistency. All fines are penalties but not all
@@ -396,7 +396,7 @@ penalties are fines.</p>
         },
         content: {
           html: "
-<h3 class='govuk-heading-s' id='quotation marks'>quotation marks</h3>
+<h3 class='govuk-heading-s' id='quotation-marks'>quotation marks</h3>
 <p class='govuk-body'>Use ‘smart’ (curly) quotes rather than 'dumb' (straight) quotes.</p>
 <p class='govuk-body'>For GOV.UK content designers, Whitehall automatically does this.</p>
 <p class='govuk-body'>See <a href='http://smartquotesforsmartpeople.com/' class='govuk-link'>Smart Quotes


### PR DESCRIPTION
Some IDs on this page had spaces in them, which is invalid. I have added hyphens to connect so they are one word IDs