### PR TITLE
Remove list role from unordered lists 

### DIFF
--- a/src/hmrc-design-patterns/currency-input/index.njk
+++ b/src/hmrc-design-patterns/currency-input/index.njk
@@ -29,12 +29,14 @@ layout: twoColumnPage.njk
 <p class="govuk-body">
   The user enters the amount of money.</p>
 <p class="govuk-body">Allow the user to enter numbers with or without:</p>
- <ul class="govuk-list govuk-list--bullet" role="list">
-<li>spaces</li>
-<li>commas</li>
-<li>pound symbols (£)</li>
-<li>full stops - to indicate pence</li>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>spaces</li>
+  <li>commas</li>
+  <li>pound symbols (£)</li>
+  <li>full stops - to indicate pence</li>
 </ul>
+
 <p class="govuk-body">You should allow the user to enter numbers up to one or 2 decimal places, for example £10.4 or £10.40.</p>
 <p class="govuk-body">Remove these characters and round up or down any amounts if necessary before validating.</p>
 

--- a/src/hmrc-design-patterns/hmrc-banner/index.njk
+++ b/src/hmrc-design-patterns/hmrc-banner/index.njk
@@ -22,8 +22,9 @@ Use this pattern if the user needs to know they are dealing with HMRC. For examp
 When not to use
 </h2>
 <p class="govuk-body"> Do not use this pattern: </p>
+
 <ul class="govuk-list govuk-list--bullet">
-<li> when the user does not need to know they are dealing with HMRC.</li>
+  <li> when the user does not need to know they are dealing with HMRC.</li>
   <li>for HMRC internal services – use the <a class="govuk-link" href="../internal-header">Internal header</a></li>
 
 </ul>
@@ -35,9 +36,10 @@ When not to use
 <p class="govuk-body">
   The HMRC banner should sit below the <a class="govuk-link" href="https://design-system.service.gov.uk/components/header/">GOV.UK header</a> and the <a class="govuk-link" href="https://design-system.service.gov.uk/components/phase-banner/">Phase banner</a>, and above the <a class="govuk-link" href="../welsh-language-toggle">Welsh language toggle</a>.</p>
 <p class="govuk-body">It should have:</p>
- <ul class="govuk-list govuk-list--bullet" role="list">
-<li>the HMRC logo</li>
-<li>a vertical teal bar on the left side</li>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>the HMRC logo</li>
+  <li>a vertical teal bar on the left side</li>
 </ul>
 
   {{


### PR DESCRIPTION
Currency Input and HMRC Banner pages had a 'role="list' attribute on <ul> tags, which is unnecessary