### PR TITLE
Updating link text to reflect link direction

### DIFF
--- a/src/hmrc-content-guide/tariff-notices/index.njk
+++ b/src/hmrc-content-guide/tariff-notices/index.njk
@@ -76,5 +76,5 @@ This Tariff notice is published for information purposes only.',
 <h3 class="govuk-heading-m">Collection page</h3>
 
 <p class="govuk-body">
-Add the document to the <a href="https://www.gov.uk/government/collections/tariff-notices" class="govuk-link">Tariff notices</a> document collection. Do not create a public change note.
+Add the document to the <a href="https://www.gov.uk/government/collections/tariff-notices" class="govuk-link">GOV.UK Tariff notices</a> document collection. Do not create a public change note.
 </p>

--- a/src/hmrc-content-guide/tariff-quota-notices/index.njk
+++ b/src/hmrc-content-guide/tariff-quota-notices/index.njk
@@ -28,5 +28,5 @@ Description (Tariff quota notice xx)
 <h3 class="govuk-heading-m">Collection page</h3>
 
 <p class="govuk-body">
-Add the document to the <a href="https://www.gov.uk/government/collections/tariff-quota-notices-2014" class="govuk-link">Tariff quota notices</a> document collection. Do not create a public change note.
+Add the document to the <a href="https://www.gov.uk/government/collections/tariff-quota-notices-2014" class="govuk-link">GOV.UK Tariff quota notices</a> document collection. Do not create a public change note.
 </p>

--- a/src/hmrc-content-guide/tariff-stop-press-notices/index.njk
+++ b/src/hmrc-content-guide/tariff-stop-press-notices/index.njk
@@ -54,5 +54,5 @@ See the [UK Trade Tariff](https://www.gov.uk/trade-tariff) for the full duty rat
 <h3 class="govuk-heading-m">Collection page</h3>
 
 <p class="govuk-body">
-Add the document to the <a href="https://www.gov.uk/government/collections/tariff-stop-press-notices" class="govuk-link">Tariff stop press notices</a> document collection. Do not create a public change note.
+Add the document to the <a href="https://www.gov.uk/government/collections/tariff-stop-press-notices" class="govuk-link">GOV.UK Tariff stop press notices</a> document collection. Do not create a public change note.
 </p>


### PR DESCRIPTION
The links on the pages edited all had links which were the same as the page title, however the links themselves direct to a GOV.UK page. I have added GOV.UK to each of the links to better reflect where they take the user to.