### PR TITLE
VoiceOver reads out a single line twice due to a line break

### DIFF
--- a/src/hmrc-design-patterns/accounts-office-reference/index.njk
+++ b/src/hmrc-design-patterns/accounts-office-reference/index.njk
@@ -125,7 +125,10 @@ status: experimental
 </h4>
 
 <p class="govuk-body">
-  Say ‘Enter [whatever it is]’.<br/>
+  Say ‘Enter [whatever it is]’.
+</p>
+
+<p class="govuk-body">
   For example, ‘Enter your Accounts Office reference’.
 </p>
 
@@ -134,7 +137,10 @@ status: experimental
 </h4>
 
 <p class="govuk-body">
-  Say ‘Enter [whatever it is] in the correct format’.<br>
+  Say ‘Enter [whatever it is] in the correct format’.
+</p>
+
+<p class="govuk-body">
   For example, ‘Enter your Accounts Office reference in the correct format’
 </p>
 

--- a/src/hmrc-design-patterns/employer-paye-reference/index.njk
+++ b/src/hmrc-design-patterns/employer-paye-reference/index.njk
@@ -134,7 +134,10 @@ layout: twoColumnPage.njk
 </h4>
 
 <p class="govuk-body">
-  Say ‘Enter [whatever it is]’.<br/>
+  Say ‘Enter [whatever it is]’.
+</p>
+
+<p class="govuk-body">
   For example, ‘Enter Anycompany’s employer PAYE reference’.
 </p>
 
@@ -143,7 +146,10 @@ layout: twoColumnPage.njk
 </h4>
 
 <p class="govuk-body">
-  Say ‘Enter [whatever it is] in the correct format’.<br>
+  Say ‘Enter [whatever it is] in the correct format’.
+</p>
+
+<p class="govuk-body">
   For example, ‘Enter Anycompany’s employer PAYE reference in the correct format’.
 </p>
 

--- a/src/hmrc-design-patterns/unique-taxpayer-reference/index.njk
+++ b/src/hmrc-design-patterns/unique-taxpayer-reference/index.njk
@@ -143,7 +143,10 @@ layout: twoColumnPage.njk
 </h4>
 
 <p class="govuk-body">
-  Say ‘Enter [whatever it is]’.<br>
+  Say ‘Enter [whatever it is]’.
+</p>
+
+<p class="govuk-body">
   For example, ‘Enter your Self Assessment Unique Taxpayer Reference’.
 </p>
 
@@ -152,7 +155,10 @@ layout: twoColumnPage.njk
 </h4>
 
 <p class="govuk-body">
-  Say ‘Enter [whatever it is] in the correct format’.<br>
+  Say ‘Enter [whatever it is] in the correct format’.
+</p>
+
+<p class="govuk-body">
   For example, ‘Enter your partnership’s Self Assessment Unique Taxpayer Reference in the correct format’.
 </p>
 

--- a/src/hmrc-design-patterns/vat-registration-number/index.njk
+++ b/src/hmrc-design-patterns/vat-registration-number/index.njk
@@ -134,6 +134,9 @@ layout: twoColumnPage.njk
 
 <p class="govuk-body">
   Say ‘Enter [whatever it is] in the correct format’.
+</p>
+
+<p class="govuk-body">
   For example, ‘Enter your VAT registration number in the correct format’.
 </p>
 


### PR DESCRIPTION
Separating the paragraph into 2 paragraphs to avoid line break, which fixes this issue.