### PR TITLE
Experimental tag falls into the heading at 400% page zoom

### DIFF
--- a/application/templates/partials/_phaseBanner.njk
+++ b/application/templates/partials/_phaseBanner.njk
@@ -6,7 +6,7 @@
     {% endif %}
 
     {% set statusText = params.statusText or defaultStatusText %}
-    <div class="govuk-!-padding-bottom-8 hmrc-phase-banner">
+    <div class="govuk-!-padding-bottom-8 govuk-!-padding-top-2 hmrc-phase-banner">
       <strong class="govuk-tag govuk-!-margin-top-4 govuk-!-margin-bottom-2">
         {{- status -}}
       </strong>


### PR DESCRIPTION
Added top padding to separate the experimental tag more from the heading, so that at 400% zoom they still have some spacing. Currently they are touching at 400%.