### PR TITLE
Updating focus styles to highlight the text rather than surrounding box

### DIFF
--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -47,7 +47,7 @@
   transform: rotate(180deg);
 }
 
-// Navigation
+//Navigation
 
 .app-pane__subnav {
   .govuk-heading-m > a {
@@ -70,10 +70,6 @@
 }
 
 .app-subnav {
-  // Since the back to top link is outside the flow of the document we need to create a space for it.
-  // This number is magic and was determined by manually judging the visual spacing.
-  margin-bottom: 100px;
-  padding: 0 govuk-spacing(3) 0 0;
   @include govuk-font(19);
 }
 
@@ -92,6 +88,7 @@
 }
 
 .app-subnav__section-item {
+  padding: govuk-spacing(3) 0;
 
   @include govuk-media-query(desktop) {
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;

--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -80,6 +80,7 @@
 .app-subnav__section {
   padding: 0 0 govuk-spacing(4);
   list-style-type: none;
+  border-bottom: 1px solid #b1b4b6;
 
   &:last-child {
     border-bottom: none;
@@ -91,7 +92,7 @@
 }
 
 .app-subnav__section-item {
-  
+
   @include govuk-media-query(desktop) {
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
 

--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -47,7 +47,7 @@
   transform: rotate(180deg);
 }
 
-//Navigation
+// Navigation
 
 .app-pane__subnav {
   .govuk-heading-m > a {
@@ -70,44 +70,49 @@
 }
 
 .app-subnav {
+  // Since the back to top link is outside the flow of the document we need to create a space for it.
+  // This number is magic and was determined by manually judging the visual spacing.
+  margin-bottom: 100px;
+  padding: 0 govuk-spacing(3) 0 0;
   @include govuk-font(19);
 }
 
 .app-subnav__section {
-  margin: 0 0 govuk-spacing(4) 0;
-  padding: 0;
+  padding: 0 0 govuk-spacing(4);
   list-style-type: none;
-  border-bottom: 1px solid $govuk-border-colour;
-  padding-bottom: govuk-spacing(4);
 
   &:last-child {
     border-bottom: none;
   }
-
-  @include govuk-media-query($from: desktop) {
-    margin-left: -14px;
-  }
 }
 
 .app-subnav__link {
-  display: block;
-  padding: govuk-spacing(3) 0;
   text-decoration: none;
+}
 
+.app-subnav__section-item {
+  
   @include govuk-media-query(desktop) {
-    padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) govuk-spacing(2);
-    border-left: 4px solid transparent;
+    padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
 
     &:hover {
+      $_current-indicator-width: 4px;
+      margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+      padding-left: govuk-spacing(2);
+      border-left: 4px solid govuk-colour("blue");
       border-left-color: $govuk-link-hover-colour;
     }
   }
 }
 
+.app-subnav__section-item--current {
+  $_current-indicator-width: 4px;
+  margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+  padding-left: govuk-spacing(2);
+  border-left: $_current-indicator-width solid govuk-colour("blue");
+  background-color: govuk-colour("white");
+}
+
 .app-subnav__section-item--current .app-subnav__link {
   font-weight: bold;
-
-  @include govuk-media-query(desktop) {
-    border-left-color: $govuk-link-colour;
-  }
 }

--- a/application/scss/components/_tabs.scss
+++ b/application/scss/components/_tabs.scss
@@ -17,6 +17,7 @@
 .app-tabs__item {
   display: inline-block;
   position: relative;
+  padding: govuk-spacing(3);
   z-index: 2;
   margin: 0;
 
@@ -25,7 +26,6 @@
 
     display: block;
     margin-top: -1px;
-    padding: govuk-spacing(3);
     border-top: 2px solid transparent;
     border-bottom: 2px solid transparent;
     color: $govuk-link-colour;


### PR DESCRIPTION
Currently, for both the navigation items and the HTML/Nunjucks tabs, the box surrounding the text is highlighted on focus. Changed the padding around to make it only highlight the text instead.