### PR TITLE
Changing the menu to use a button rather than checkbox

### DIFF
--- a/application/assets/javascripts/components/accordion.js
+++ b/application/assets/javascripts/components/accordion.js
@@ -25,7 +25,7 @@ Accordion.prototype.attachClick = function (link) {
 
 Accordion.prototype.handleClick = function (evt) {
   var section = evt.target.hash[1].trim().toLowerCase()
-  var button = this.$module.querySelector('#' + this.$mappedSectionButtons[section]).parentNode
+  var button = this.$module.querySelector('#' + this.$mappedSectionButtons[section])
   if (button.getAttribute('aria-expanded') !== 'true') {
     button.click()
   }

--- a/application/assets/javascripts/components/accordion.js
+++ b/application/assets/javascripts/components/accordion.js
@@ -25,7 +25,7 @@ Accordion.prototype.attachClick = function (link) {
 
 Accordion.prototype.handleClick = function (evt) {
   var section = evt.target.hash[1].trim().toLowerCase()
-  var button = this.$module.querySelector('#' + this.$mappedSectionButtons[section])
+  var button = this.$module.querySelector('#' + this.$mappedSectionButtons[section]).parentNode
   if (button.getAttribute('aria-expanded') !== 'true') {
     button.click()
   }

--- a/application/assets/javascripts/components/subnav.js
+++ b/application/assets/javascripts/components/subnav.js
@@ -1,23 +1,69 @@
 const toggleActiveClass = 'active'
 
 function SubNavToggle ($module) {
-  this.$module = $module
+  this.$module = $module || document
+
+  this.$nav = this.$module.querySelector('.app-pane__subnav')
+  this.$navToggler = this.$module.querySelector('.app-subnav-toggle__button')
+
+  this.mobileNavOpen = false
+
+  this.mql = null
+}
+
+SubNavToggle.prototype.setHiddenStates = function () {
+  if (this.mql === null || !this.mql.matches) {
+    if (!this.mobileNavOpen) {
+      this.$nav.setAttribute('hidden', '')
+    }
+
+    this.$navToggler.removeAttribute('hidden')
+  } else if (this.mql === null || this.mql.matches) {
+    this.$nav.removeAttribute('hidden')
+    this.$navToggler.setAttribute('hidden', '')
+  }
+}
+
+SubNavToggle.prototype.setInitialAriaStates = function () {
+  this.$navToggler.setAttribute('aria-expanded', 'false')
+}
+
+SubNavToggle.prototype.bindUIEvents = function () {
+  var $nav = this.$nav
+  var $navToggler = this.$navToggler
+
+  $navToggler.addEventListener('click', function (event) {
+    if (this.mobileNavOpen) {
+      $navToggler.parentNode.classList.remove(toggleActiveClass)
+      $nav.setAttribute('hidden', '')
+
+      $navToggler.setAttribute('aria-expanded', 'false')
+
+      this.mobileNavOpen = false
+    } else {
+      $navToggler.parentNode.classList.add(toggleActiveClass)
+      $nav.removeAttribute('hidden')
+
+      $navToggler.setAttribute('aria-expanded', 'true')
+
+      this.mobileNavOpen = true
+    }
+  }.bind(this))
 }
 
 SubNavToggle.prototype.init = function() {
   if (!this.$module) {
     return
   }
-  this.$module.addEventListener('click', this.handleClick.bind(this))
 
-}
-
-SubNavToggle.prototype.handleClick = function(event) {
-  if (event.target.parentNode.classList.contains(toggleActiveClass)) {
-    this.$module.classList.remove(toggleActiveClass)
-  } else {
-    this.$module.classList.add(toggleActiveClass)
+  if (typeof window.matchMedia === 'function') {
+    this.mql = window.matchMedia('(min-width: 48.0625em)')
+    this.mql.addEventListener('change', this.setHiddenStates.bind(this))
   }
+
+  this.setHiddenStates()
+  this.setInitialAriaStates()
+  this.bindUIEvents()
 }
 
 export default SubNavToggle

--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -15,6 +15,7 @@
   text-align: right;
   padding: 15px;
   float: right;
+
   @include govuk-media-query(desktop) {
     display: none;
     padding: 20px;
@@ -25,11 +26,14 @@
   @include govuk-font(19);
   cursor: pointer;
   border: 0px solid $black;
-  margin-top: 22px;
-  padding: 20px 0px;
+  margin-top: 40px;
   font-size: 19px;
   display: inline-block;
   background: transparent;
+
+  &:focus {
+    @include govuk-focused-text;
+  }
 }
 
 .app-subnav-toggle__button::after {

--- a/application/scss/components/_subnav.scss
+++ b/application/scss/components/_subnav.scss
@@ -21,7 +21,7 @@
   }
 }
 
-.app-subnav-toggle__label {
+.app-subnav-toggle__button {
   @include govuk-font(19);
   cursor: pointer;
   border: 0px solid $black;
@@ -29,9 +29,10 @@
   padding: 20px 0px;
   font-size: 19px;
   display: inline-block;
+  background: transparent;
 }
 
-.app-subnav-toggle__label::after {
+.app-subnav-toggle__button::after {
   display: inline-block;
   width: 0;
   height: 0;
@@ -43,7 +44,7 @@
   margin-left: 5px;
 }
 
-.app-subnav-toggle.active .app-subnav-toggle__label::after{
+.app-subnav-toggle.active .app-subnav-toggle__button::after{
   transform: rotate(180deg);
 }
 
@@ -63,9 +64,13 @@
       background-color: $govuk-focus-colour;
     }
   }
-  display: none;
-  @include govuk-media-query(desktop) {
+  @include govuk-media-query($until: desktop) {
     display: block;
+  }
+
+  .js-enabled [hidden],
+  .js-enabled &[hidden] {
+    display: none;
   }
 }
 

--- a/application/templates/twoColumnPage.njk
+++ b/application/templates/twoColumnPage.njk
@@ -30,57 +30,56 @@
 
 
     {% set indexPageLink = '/' ~ section ~ '/' %}
-
-    <div class="app-subnav-toggle" data-module="subnav-toggle">
-      <label for="app-subnav-toggle" class="app-subnav-toggle__label">Menu</label>
-    </div>
-    <input type="checkbox" id="app-subnav-toggle">
-
-    <nav class="app-pane__subnav">
-
-      <h2 class="govuk-heading-m">
-        {% set isRoot = '/' ~ filepath === indexPageLink %}
-        {%- if not isRoot -%}<a href="{{ indexPageLink }}">{%- endif -%}
-          {{ sectionTitle or title }}
-        {%- if not isRoot -%}</a>{%- endif -%}
-      </h2>
-
-      <div class="app-subnav">
-
-        {%- if primaryNavItems | length > 0 -%}
-          <ul class="app-subnav__section">
-            {%- for item in primaryNavItems -%}
-              {%- set isActive = item.filepath ~ '/' === filepath -%}
-
-              {%- if item.placement === 'primary' -%}
-                <li class="app-subnav__section-item{% if isActive %} app-subnav__section-item--current{% endif %}">
-                  <a class="app-subnav__link govuk-link" href="/{{ item.href }}">
-                    {{item.text}}
-                  </a>
-                </li>
-              {%- endif -%}
-            {%- endfor -%}
-          </ul>
-        {%- endif -%}
-
-        {%- if secondaryNavItems | length > 0 -%}
-          <ul class="app-subnav__section">
-          {%- for item in secondaryNavItems -%}
-            {%- set isActive = item.filepath ~ '/' === filepath -%}
-
-            {%- if item.placement === 'secondary' -%}
-              <li class="app-subnav__section-item{%if isActive%} app-subnav__section-item--current{% endif %}">
-                <a class="app-subnav__link govuk-link" href="/{{ item.href }}">
-                  {{item.text}}
-                </a>
-              </li>
-            {%- endif -%}
-          {%- endfor -%}
-          </ul>
-        {%- endif -%}
+    <div data-module="subnav-toggle">
+      <div class="app-subnav-toggle">
+        <button hidden aria-controls="app-navigation" class="app-subnav-toggle__button">Menu</button>
       </div>
-    </nav>
 
+        <nav role="navigation" class="app-pane__subnav" id="app-navigation">
+
+          <h2 class="govuk-heading-m">
+            {% set isRoot = '/' ~ filepath === indexPageLink %}
+            {%- if not isRoot -%}<a href="{{ indexPageLink }}">{%- endif -%}
+              {{ sectionTitle or title }}
+            {%- if not isRoot -%}</a>{%- endif -%}
+          </h2>
+
+          <div class="app-subnav">
+
+            {%- if primaryNavItems | length > 0 -%}
+              <ul class="app-subnav__section">
+                {%- for item in primaryNavItems -%}
+                  {%- set isActive = item.filepath ~ '/' === filepath -%}
+
+                  {%- if item.placement === 'primary' -%}
+                    <li class="app-subnav__section-item{% if isActive %} app-subnav__section-item--current{% endif %}">
+                      <a class="app-subnav__link govuk-link" href="/{{ item.href }}">
+                        {{item.text}}
+                      </a>
+                    </li>
+                  {%- endif -%}
+                {%- endfor -%}
+              </ul>
+            {%- endif -%}
+
+            {%- if secondaryNavItems | length > 0 -%}
+              <ul class="app-subnav__section">
+              {%- for item in secondaryNavItems -%}
+                {%- set isActive = item.filepath ~ '/' === filepath -%}
+
+                {%- if item.placement === 'secondary' -%}
+                  <li class="app-subnav__section-item{%if isActive%} app-subnav__section-item--current{% endif %}">
+                    <a class="app-subnav__link govuk-link" href="/{{ item.href }}">
+                      {{item.text}}
+                    </a>
+                  </li>
+                {%- endif -%}
+              {%- endfor -%}
+              </ul>
+            {%- endif -%}
+          </div>
+        </nav>
+    </div>
     <div class="app-pane__content">
       <main class="app-content" id="main-content">
         <div class="govuk-grid-row">


### PR DESCRIPTION
The menu will now use a button instead of the current label/input/checkbox set up. This is to ensure that if the design system is viewed with no styles, there isn't a useless checkbox. With this, the navigation shows in full with no extra element as the button is hidden by default.