### PR TITLE
UTR amends

### DIFF
--- a/src/examples/unique-taxpayer-reference/corporation-tax-welsh/index.njk
+++ b/src/examples/unique-taxpayer-reference/corporation-tax-welsh/index.njk
@@ -5,15 +5,14 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+<h1 class="govuk-heading-l">Beth yw’ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Treth Gorfforaeth?</h1>
+
+<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">Mae modd dod o hyd i UTR sydd ar goll</a>.</p>
+
 {{
   govukInput({
-    label: {
-      text: "Beth yw’ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Treth Gorfforaeth?",
-      isPageHeading: true,
-      classes: "govuk-label--xl"
-    },
-    hint: {
-      html: 'Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Treth Gorfforaeth. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’. <a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">Mae modd dod o hyd i UTR sydd ar goll</a>.'
+   hint: {
+      html: 'Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Treth Gorfforaeth. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’.'
     },
     id: "utr",
     name: "utr",

--- a/src/examples/unique-taxpayer-reference/corporation-tax-welsh/index.njk
+++ b/src/examples/unique-taxpayer-reference/corporation-tax-welsh/index.njk
@@ -5,7 +5,7 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<h1 class="govuk-heading-l">Beth yw’ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Treth Gorfforaeth?</h1>
+<h1 class="govuk-heading-l">Beth yw’ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Treth Gorfforaeth (UTR)?</h1>
 
 <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">Mae modd dod o hyd i UTR sydd ar goll</a>.</p>
 

--- a/src/examples/unique-taxpayer-reference/corporation-tax/index.njk
+++ b/src/examples/unique-taxpayer-reference/corporation-tax/index.njk
@@ -5,15 +5,14 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+<h1 class="govuk-heading-l">What is your Corporation Tax Unique Taxpayer Reference (UTR)?</h1>
+
+<p class="govuk-body">You can <a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">find a lost UTR</a>.</p>
+
 {{
   govukInput({
-    label: {
-      text: "What is your Corporation Tax Unique Taxpayer Reference?",
-      isPageHeading: true,
-      classes: "govuk-label--xl"
-    },
     hint: {
-      html: 'This is 10 numbers, for example 1234567890. It will be on tax returns and other letters about Corporation Tax. It may be called ‘reference’, ‘UTR’ or ‘official use’. You can <a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">find a lost UTR number</a>.'
+      html: 'This is 10 numbers, for example 1234567890. It will be on tax returns and other letters about Corporation Tax. It may be called ‘reference’, ‘UTR’ or ‘official use’.'
     },
     id: "utr",
     name: "utr",

--- a/src/examples/unique-taxpayer-reference/self-assessment-welsh/index.njk
+++ b/src/examples/unique-taxpayer-reference/self-assessment-welsh/index.njk
@@ -5,7 +5,7 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<h1 class="govuk-heading-l">Beth yw'ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad?</h1>
+<h1 class="govuk-heading-l">Beth yw'ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad (UTR)?</h1>
 
 <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">Mae modd dod o hyd i UTR sydd ar goll</a>.</p>
 

--- a/src/examples/unique-taxpayer-reference/self-assessment-welsh/index.njk
+++ b/src/examples/unique-taxpayer-reference/self-assessment-welsh/index.njk
@@ -5,15 +5,14 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+<h1 class="govuk-heading-l">Beth yw'ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad?</h1>
+
+<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">Mae modd dod o hyd i UTR sydd ar goll</a>.</p>
+
 {{
   govukInput({
-    label: {
-      text: "Beth yw'ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad?",
-      isPageHeading: true,
-      classes: "govuk-label--xl"
-    },
     hint: {
-      html: 'Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Hunanasesiad. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’. <a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">Mae modd dod o hyd i UTR sydd ar goll</a>.'
+      html: 'Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Hunanasesiad. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’.'
     },
     id: "utr",
     name: "utr",

--- a/src/examples/unique-taxpayer-reference/self-assessment/index.njk
+++ b/src/examples/unique-taxpayer-reference/self-assessment/index.njk
@@ -5,21 +5,19 @@ layout: layout-example.njk
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{{
-  govukInput({
-    label: {
-      text: "What is your Self Assessment Unique Taxpayer Reference?",
-      isPageHeading: true,
-      classes: "govuk-label--xl"
-    },
-    hint: {
-      html: 'This is 10 numbers, for example 1234567890. It will be on tax returns and other letters about Self Assessment. It may be called ‘reference’, ‘UTR’ or ‘official use’. You can <a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">find a lost UTR number</a>.'
-    },
-    id: "utr",
-    name: "utr",
-    classes: "govuk-input--width-10"
-  })
-}}
+<h1 class="govuk-heading-l">What is your Self Assessment Unique Taxpayer Reference (UTR)?</h1>
+
+<p class="govuk-body">You can <a class="govuk-link" href="https://www.gov.uk/find-lost-utr-number">find a lost UTR</a>.</p>
+
+{{ govukInput({
+  hint: {
+    text: "This is 10 numbers, for example 1234567890. It will be on tax returns and other letters about Self Assessment. It may be called ‘reference’, ‘UTR’ or ‘official use’."
+  },
+  id: "utr",
+  name: "utr",
+  classes: "govuk-input--width-10"
+}) }}
+
 
 {{ govukButton({
   text: "Continue"

--- a/src/hmrc-design-patterns/unique-taxpayer-reference/index.njk
+++ b/src/hmrc-design-patterns/unique-taxpayer-reference/index.njk
@@ -1,7 +1,6 @@
 ---
 title: Unique Taxpayer Reference
 menuText: Unique Taxpayer Reference
-status: experimental
 layout: twoColumnPage.njk
 ---
 {% from "_example.njk" import example %}
@@ -59,19 +58,6 @@ layout: twoColumnPage.njk
 }}
 
 <p class="govuk-body">
-  Or you can ask for the UTR as a normal form label, separate from the <code>&lt;h1&gt;</code>.
-</p>
-
-{{
-  example({
-    item: 'unique-taxpayer-reference',
-    example: 'label',
-    welsh: 'label-welsh',
-    description: 'Employer PAYE reference as form label'
-  })
-}}
-
-<p class="govuk-body">
   Use a single text input and allow the user to enter:
 </p>
 
@@ -120,19 +106,6 @@ layout: twoColumnPage.njk
 <h3 class="govuk-heading-m" id="error-messages">
   Error messages
 </h3>
-
-<p class="govuk-body">
-  Error messages should be styled like this:
-</p>
-
-{{
-  example({
-    item: 'unique-taxpayer-reference',
-    example: 'label-error',
-    welsh: 'label-error-welsh',
-    description: 'Employer PAYE reference with error'
-  })
-}}
 
 <p class="govuk-body">
   Make sure errors follow the <a class="govuk-link" href="https://design-system.service.gov.uk/components/error-message/">guidance about error messages</a> in the GOV.UK Design System and have specific error messages for specific error states.


### PR DESCRIPTION
Agreed in 18/3/22 working group:
- Changed lost UTR link from hint to paragraph text to avoid screenreader issues
- Added UTR acronym to end of H1s

Other:
- Removed label options (with a paragraph text lost UTR link, this no longer fits the format and the lost link makes the examples more usable)
- Removed the label error example box - would have to be amended and doesn't seem necessary
- Removed experimental tag (this pattern has been published for a while, and we have had feedback)