### PR TITLE
DR-1216 Fixing issues with integration tests

### DIFF
--- a/src/examples/recognised-overseas-pension-schemes-notification-list/example/index.njk
+++ b/src/examples/recognised-overseas-pension-schemes-notification-list/example/index.njk
@@ -2,7 +2,7 @@
   layout: layout-example.njk
 ---
 
-<h3 class="govuk-heading-l">Austria</h3>
+<h2 class="govuk-heading-l">Austria</h2>
 
 <div class="call-to-action">
 <p class="govuk-body">The requirements to be a ROPS changed from 6 April 2017. You’ll need to check that the scheme you’re transferring to on or after that date meets the new requirements.</p>

--- a/src/examples/service-timeout/signed-out-default-welsh/index.njk
+++ b/src/examples/service-timeout/signed-out-default-welsh/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
     </h1>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn2" class="govuk-button govuk-!-margin-bottom-0">
         Mewngofnodi
       </button>
     </div>

--- a/src/examples/service-timeout/signed-out-default/index.njk
+++ b/src/examples/service-timeout/signed-out-default/index.njk
@@ -11,7 +11,7 @@ layout: layout-example.njk
     </h1>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn1" class="govuk-button govuk-!-margin-bottom-0">
         Sign in
       </button>
     </div>

--- a/src/examples/service-timeout/signed-out-not-saved-welsh/index.njk
+++ b/src/examples/service-timeout/signed-out-not-saved-welsh/index.njk
@@ -13,7 +13,7 @@ layout: layout-example.njk
     </p>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn4" class="govuk-button govuk-!-margin-bottom-0">
         Mewngofnodi
       </button>
     </div>

--- a/src/examples/service-timeout/signed-out-not-saved/index.njk
+++ b/src/examples/service-timeout/signed-out-not-saved/index.njk
@@ -15,7 +15,7 @@ layout: layout-example.njk
     </p>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn3" class="govuk-button govuk-!-margin-bottom-0">
         Sign in
       </button>
     </div>

--- a/src/examples/service-timeout/signed-out-saved-welsh/index.njk
+++ b/src/examples/service-timeout/signed-out-saved-welsh/index.njk
@@ -13,7 +13,7 @@ layout: layout-example.njk
     </p>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn6" class="govuk-button govuk-!-margin-bottom-0">
         Mewngofnodi
       </button>
     </div>

--- a/src/examples/service-timeout/signed-out-saved/index.njk
+++ b/src/examples/service-timeout/signed-out-saved/index.njk
@@ -13,7 +13,7 @@ layout: layout-example.njk
     </p>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn5" class="govuk-button govuk-!-margin-bottom-0">
         Sign in
       </button>
     </div>

--- a/src/examples/service-timeout/we-deleted-your-answers-welsh/index.njk
+++ b/src/examples/service-timeout/we-deleted-your-answers-welsh/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
     </h1>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn8" class="govuk-button govuk-!-margin-bottom-0">
         Dechrau eto
       </button>
     </div>

--- a/src/examples/service-timeout/we-deleted-your-answers/index.njk
+++ b/src/examples/service-timeout/we-deleted-your-answers/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
     </h1>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn7" class="govuk-button govuk-!-margin-bottom-0">
         Start again
       </button>
     </div>

--- a/src/examples/service-timeout/you-deleted-your-answers-welsh/index.njk
+++ b/src/examples/service-timeout/you-deleted-your-answers-welsh/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
     </h1>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn10" class="govuk-button govuk-!-margin-bottom-0">
         Dechrau eto
       </button>
     </div>

--- a/src/examples/service-timeout/you-deleted-your-answers/index.njk
+++ b/src/examples/service-timeout/you-deleted-your-answers/index.njk
@@ -9,7 +9,7 @@ layout: layout-example.njk
     </h1>
 
     <div class="govuk-form-group">
-      <button id="timeout-keep-signin-btn" class="govuk-button govuk-!-margin-bottom-0">
+      <button id="timeout-keep-signin-btn9" class="govuk-button govuk-!-margin-bottom-0">
         Start again
       </button>
     </div>

--- a/src/examples/use-a-digital-service/example/index.njk
+++ b/src/examples/use-a-digital-service/example/index.njk
@@ -36,7 +36,7 @@ Use this online service to submit a return.
   isStartButton: true
 }) }}
 
-<h2 class="govuk-heading-l" id="after">
+<h2 class="govuk-heading-l" id="before">
   Before you start
 </h2>
 

--- a/src/hmrc-content-style-guide/__tests__/hmrc-content-style-guide.integration.js
+++ b/src/hmrc-content-style-guide/__tests__/hmrc-content-style-guide.integration.js
@@ -34,7 +34,7 @@ describe('HMRC content style guide', () => {
     it('should open relevant section when an anchor is clicked', async () => {
       let testSectionClasses = await page.$$eval('.govuk-accordion__section', el => el[2].className )
       expect(testSectionClasses).not.toContain('govuk-accordion__section--expanded')
-      await page.click('button#accordion-default-heading-20')
+      await page.click('button[aria-controls="accordion-default-content-20"]')
       await page.$eval('#accordion-default-content-20', el => el.querySelectorAll('.govuk-link')[0].click())
       testSectionClasses = await page.$$eval('.govuk-accordion__section', el => el[2].className )
       expect(testSectionClasses).toContain('govuk-accordion__section--expanded')

--- a/src/hmrc-design-patterns/__tests__/ask-the-user-for-their-consent.integration.js
+++ b/src/hmrc-design-patterns/__tests__/ask-the-user-for-their-consent.integration.js
@@ -36,7 +36,7 @@ describe('Design pattern page rendering', () => {
   })
 
   describe('Copy snippet button', () => {
-    const buttonSelector = '#example-yes-no-question-html .app-link--copy'
+    const buttonSelector = 'button.app-copy-button'
 
     beforeEach(async () => {
       await page.click('.example-example-yes-no-question-lang ul > li:first-child > a')

--- a/src/hmrc-design-patterns/__tests__/ask-the-user-for-their-consent.integration.js
+++ b/src/hmrc-design-patterns/__tests__/ask-the-user-for-their-consent.integration.js
@@ -36,7 +36,7 @@ describe('Design pattern page rendering', () => {
   })
 
   describe('Copy snippet button', () => {
-    const buttonSelector = 'button.app-copy-button'
+    const buttonSelector = '#example-yes-no-question .app-copy-button'
 
     beforeEach(async () => {
       await page.click('.example-example-yes-no-question-lang ul > li:first-child > a')

--- a/src/hmrc-design-patterns/__tests__/ask-the-user-for-their-consent.integration.js
+++ b/src/hmrc-design-patterns/__tests__/ask-the-user-for-their-consent.integration.js
@@ -17,7 +17,7 @@ describe('Design pattern page rendering', () => {
 
   it('should have the correct meta title', async () => {
     const title = await page.title()
-    expect(title).toBe('Ask the user for their consent - HMRC Design Patterns - Design resources for HMRC – GOV.UK')
+    expect(title).toBe('Ask the user for their consent - HMRC design patterns - Design resources for HMRC – GOV.UK')
   })
 
   describe('iFrame resizer', () => {

--- a/src/hmrc-design-patterns/__tests__/hmrc-design-patterns.integration.js
+++ b/src/hmrc-design-patterns/__tests__/hmrc-design-patterns.integration.js
@@ -23,12 +23,12 @@ describe('HMRC design patterns', () => {
 
   it('should have the correct meta title', async () => {
     const title = await page.title()
-    expect(title).toBe('HMRC Design Patterns - Design resources for HMRC – GOV.UK')
+    expect(title).toBe('HMRC design patterns - Design resources for HMRC – GOV.UK')
   })
 
   it('should have the correct page heading', async () => {
     const heading = await page.$eval('h1', el => el.textContent);
-    expect(heading).toBe('HMRC Design Patterns')
+    expect(heading).toBe('HMRC design patterns')
   })
 
   describe('Sub navigation', () => {


### PR DESCRIPTION
Some of the changes we have made for the accessibility audit have caused some integration test errors. They are mostly due to changes in content or selectors.