### PR TITLE
Updating content for Slack links to reflect direction

### DIFF
--- a/src/hmrc-design-patterns/index.njk
+++ b/src/hmrc-design-patterns/index.njk
@@ -54,5 +54,4 @@ If you have a question, idea or suggestion you can:
 
 <ul class="govuk-list govuk-list--bullet">
   <li>email the design resources team at <a class="govuk-link" href="mailto:design.resources-g@digital.hmrc.gov.uk">design.resources-g@digital.hmrc.gov.uk</a></li>
-  <li>get in touch with <a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">#team-design-system</a> on HMRC Slack <a class="govuk-link" href="slack://channel?team=T04RY81HB&amp;id=C014S77JCJW">(opens in app if you have it)</a></li>
-</ul>
+      <li><a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">get in touch through Slack (opens in app if you have it)</a></li></ul>

--- a/src/hmrc-design-patterns/index.njk
+++ b/src/hmrc-design-patterns/index.njk
@@ -54,5 +54,5 @@ If you have a question, idea or suggestion you can:
 
 <ul class="govuk-list govuk-list--bullet">
   <li>email the design resources team at <a class="govuk-link" href="mailto:design.resources-g@digital.hmrc.gov.uk">design.resources-g@digital.hmrc.gov.uk</a></li>
-  <li>get in touch with <a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">#team-design-system</a> on HMRC Slack <a class="govuk-link" href="slack://channel?team=T04RY81HB&amp;id=C014S77JCJW">(open in app)</a></li>
+  <li>get in touch with <a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">#team-design-system</a> on HMRC Slack <a class="govuk-link" href="slack://channel?team=T04RY81HB&amp;id=C014S77JCJW">(opens in app if you have it)</a></li>
 </ul>

--- a/src/index.njk
+++ b/src/index.njk
@@ -127,7 +127,7 @@ layout: oneColumnPage.njk
       </li>
 
       <li>
-        get in touch with <a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">#team-design-system</a> on HMRC Slack <a class="govuk-link" href="slack://channel?team=T04RY81HB&amp;id=C014S77JCJW">(open in app)</a>
+        get in touch with <a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">#team-design-system</a> on HMRC Slack <a class="govuk-link" href="slack://channel?team=T04RY81HB&amp;id=C014S77JCJW">(opens in app if you have it)</a>
       </li>
     </ul>
   </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -127,7 +127,7 @@ layout: oneColumnPage.njk
       </li>
 
       <li>
-        get in touch with <a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">#team-design-system</a> on HMRC Slack <a class="govuk-link" href="slack://channel?team=T04RY81HB&amp;id=C014S77JCJW">(opens in app if you have it)</a>
+        <a class="govuk-link" href="https://hmrcdigital.slack.com/archives/C014S77JCJW">get in touch through Slack (opens in app if you have it)</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Content rewrote to make it clear that Slack will open in app if it is installed