### PR TITLE
'HMRC email updates' content pattern changes

### DIFF
--- a/src/patterns-hmrc-govuk-team/hmrc-email-updates-videos-webinars-community-forums/index.njk
+++ b/src/patterns-hmrc-govuk-team/hmrc-email-updates-videos-webinars-community-forums/index.njk
@@ -108,7 +108,10 @@ Watch a video [about/to find out] [sub topic].
 
 [Title of video](link).
 
-You will [find out/learn about] [details of what the user will find in the video].',
+You will [find out/learn about]:
+
+* [detail]
+* [detail]',
       canCopy: true
     })
   }}
@@ -143,7 +146,10 @@ Watch a video [about/to find out] [sub topic].
 
 [Title of video](link).
 
-You will [find out/learn about] [details of what the user will find in the video].',
+You will [find out/learn about]:
+
+* [detail]
+* [detail]',
       canCopy: true
     })
   }}
@@ -158,7 +164,10 @@ Watch a collection of videos [about/to find out] [sub topic].
 
 [Title of video](link).
 
-You will [find out/learn about] [details of what the user will find in the collection].',
+You will [find out/learn about]:
+
+* [detail]
+* [detail]',
       canCopy: true
     })
   }}


### PR DESCRIPTION
I have changed the example boxes to include bullet point lists on [HRMC email updates, video, webinars and commiunity forums](https://design.tax.service.gov.uk/patterns-hmrc-govuk-team/hmrc-email-updates-videos-webinars-community-forums/).

