### PR TITLE
Updated 'Forms in a detailed guide' and 'Forms in a publication'

### DIFF
--- a/src/patterns-hmrc-govuk-team/forms-detailed-guide/index.njk
+++ b/src/patterns-hmrc-govuk-team/forms-detailed-guide/index.njk
@@ -60,10 +60,7 @@ s3. Print and post it to HMRC, using the postal address shown on the form.
     })
   }}
 
-  <p class="govuk-body">
-You should check with the DFOM (Digital Forms and Outbound Mail) team if you
-need to include the following:
-</p>
+  <p class="govuk-body">You should check with the team who are building the form and the subject matter expert if you need to include the following:</p>
 
   {{
     codeSnippet({

--- a/src/patterns-hmrc-govuk-team/forms-publication/index.njk
+++ b/src/patterns-hmrc-govuk-team/forms-publication/index.njk
@@ -72,10 +72,7 @@ You’ll need to fill in the form fully before you can print it. You cannot save
     })
   }}
 
-<p class="govuk-body">
-You should check with the DFOM (Digital Forms and Outbound Mail)
-team if you need to include the following:
-</p>
+  <p class="govuk-body">You should check with the team who are building the form and the subject matter expert if you need to include the following:</p>
 
 {{
     codeSnippet({


### PR DESCRIPTION
Updated a line of text in:
- [forms: in a detailed guide](https://design.tax.service.gov.uk/patterns-hmrc-govuk-team/forms-detailed-guide/)
- [forms: in a publication](https://design.tax.service.gov.uk/patterns-hmrc-govuk-team/forms-publication/)

I changed 'You should check with the DFOM (Digital Forms and Outbound Mail) team if you need to include the following:' to 
'You should check with the team who are building the form and the subject matter expert if you need to include the following:'.
