### PR TITLE
Archived 'Anti-dumping duty measures'

### DIFF
--- a/src/patterns-hmrc-govuk-team/anti-dumping-measures/index.njk
+++ b/src/patterns-hmrc-govuk-team/anti-dumping-measures/index.njk
@@ -1,5 +1,6 @@
 ---
 title: Anti-dumping duty measures
+status: archived
 menuText: Anti-dumping duty measures
 layout: twoColumnPage.njk
 ---


### PR DESCRIPTION
Archived the '[Anti-dumping duty measures](https://design.tax.service.gov.uk/hmrc-content-guide/anti-dumping-measures/)' content pattern as it is no longer needed.