### PR TITLE
Updated the 'tariff stop press notices' pattern

### DIFF
--- a/src/patterns-hmrc-govuk-team/tariff-stop-press-notices/index.njk
+++ b/src/patterns-hmrc-govuk-team/tariff-stop-press-notices/index.njk
@@ -42,7 +42,7 @@ Use this pattern to tell users about changes to the UK Trade Tariff, Customs Han
 
 To stop getting the Tariff stop press notices, or to add recipients to the distribution list, email: <tariff.management@hmrc.gov.uk>.
 
-See the [UK Trade Tariff](https://www.gov.uk/trade-tariff) for the full duty rate, unit of quantity, preferences, quotas, footnotes and VAT rate.',
+Check the [UK Trade Tariff](https://www.gov.uk/trade-tariff) for the full duty rate, unit of quantity, preferences, quotas, footnotes and VAT rate.',
       canCopy: true
     })
   }}


### PR DESCRIPTION
Small change in wording for accessibility reasons. Changed 'See the UK Trade Tariff' to 'Check the UK Trade Tariff' as not all users can 'see'.

https://design.tax.service.gov.uk/patterns-hmrc-govuk-team/tariff-stop-press-notices/