### PR TITLE
File upload

### DIFF
--- a/src/examples/file-upload/upload-a-single-file/index.njk
+++ b/src/examples/file-upload/upload-a-single-file/index.njk
@@ -1,18 +1,24 @@
 ---
 layout: layout-example.njk
 ---
-{% from "hmrc/components/page-heading/macro.njk"  import hmrcPageHeading %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
 <div class="govuk-form-group">
-  <h1 class="govuk-heading-xl">Upload receipt</h1>
-
-<div id="file-upload-1-hint" class="govuk-hint">
-    You can upload your receipt as a scanned copy or photo of the original. The selected file must be smaller than 100MB.
+  {{ govukFileUpload({
+    id: "file-upload-1",
+    name: "file-upload-1",
+    hint: {
+      text: "You can upload your receipt as a scanned copy or photo of the original. The selected file must be smaller than 100MB."
+    },
+    label: {
+      text: "Upload receipt",
+      classes: "govuk-label--xl",
+      isPageHeading: true
+    }
+  }) }}
 </div>
 
-  <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file">
-  
-</div>
-
-<button class="govuk-button" data-module="govuk-button">Continue</button>
+{{ govukButton({
+  text: "Continue"
+}) }}

--- a/src/examples/file-upload/upload-additional-files/index.njk
+++ b/src/examples/file-upload/upload-additional-files/index.njk
@@ -9,12 +9,12 @@ layout: layout-example.njk
       hmrcAddToAList({
         itemList: [
           {
-            name: 'receipt1.jpg',
+            name: 'receipt1.jpg file uploaded',
             changeUrl: '#',
             removeUrl: '#'
           },
           {
-            name: 'receipt2.jpg',
+            name: 'receipt2.jpg 33% uploaded',
             changeUrl: '#',
             removeUrl: '#'
           }

--- a/src/examples/file-upload/upload-additional-files/index.njk
+++ b/src/examples/file-upload/upload-additional-files/index.njk
@@ -5,6 +5,79 @@ layout: layout-example.njk
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">You have added 2 receipts</h1>
+    <h2 class="govuk-heading-m">Upload receipts</h2>
+    <div class="govuk-form-group">
+
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+            receipt1.jpg
+          </dt>
+          <dd class="govuk-summary-list__value">
+            file uploaded
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <ul class="govuk-summary-list__actions-list">
+              <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="#"><span aria-hidden="true">Remove</span><span class="govuk-visually-hidden">Remove receipt1.jpg file uploaded from the list</span></a></li>
+            </ul>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+            receipt2.jpg
+          </dt>
+          <dd class="govuk-summary-list__value">
+            33% uploaded
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <ul class="govuk-summary-list__actions-list">
+              <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="#"><span aria-hidden="true">Remove</span><span class="govuk-visually-hidden">Remove receipt2.jpg 33% uploaded from the list</span></a></li>
+            </ul>
+          </dd>
+        </div>
+      </dl>
+
+    </div>
+    <form method="post" novalidate action="">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="add-another-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend govuk-fieldset__legend--m">
+            Do you need to add another receipt?
+          </legend>
+          <div id="add-another-hint" class="govuk-hint">
+
+          </div>
+          <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="add-another" name="add-another" type="radio" value="Yes">
+              <label class="govuk-label govuk-radios__label" for="add-another">
+                Yes
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="add-another-2" name="add-another" type="radio" value="No">
+              <label class="govuk-label govuk-radios__label" for="add-another-2">
+                No
+              </label>
+            </div>
+          </div>
+
+        </fieldset>
+      </div>
+
+      <button class="govuk-button" data-module="govuk-button">
+        Continue
+      </button>
+    </form>
+
+  </div>
+</div>
+
+{#
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     {{
       hmrcAddToAList({
         itemList: [
@@ -27,8 +100,10 @@ layout: layout-example.njk
         messages: {
           yes: 'Yes',
           no: 'No'
-        }
+        },
+        itemSize: 'long'
       })
     }}
   </div>
 </div>
+#}

--- a/src/examples/file-upload/upload-additional-files/index.njk
+++ b/src/examples/file-upload/upload-additional-files/index.njk
@@ -1,53 +1,34 @@
 ---
 layout: layout-example.njk
 ---
-{% from "hmrc/components/page-heading/macro.njk"  import hmrcPageHeading %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-
-<h1 class="govuk-heading-xl">Upload receipts</h1>
+{%- from "hmrc/components/add-to-a-list/macro.njk" import hmrcAddToAList -%}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">Files added</h2>
-
-    <dl class="govuk-summary-list">
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">receipt1.jpg</dt>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#">Remove</a></dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">receipt2.jpg</dt>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#">Remove</a></dd>
-      </div>
-
-    </dl>
-
+    {{
+      hmrcAddToAList({
+        itemList: [
+          {
+            name: 'receipt1.jpg',
+            changeUrl: '#',
+            removeUrl: '#'
+          },
+          {
+            name: 'receipt2.jpg',
+            changeUrl: '#',
+            removeUrl: '#'
+          }
+        ],
+        itemType: {
+          singular: 'receipt',
+          plural: 'receipts',
+          formAction: '#'
+        },
+        messages: {
+          yes: 'Yes',
+          no: 'No'
+        }
+      })
+    }}
   </div>
 </div>
-
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset">
-
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Do you want to upload another receipt?</legend>
-
-    <div class="govuk-radios">
-
-      <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="another" name="another" type="radio" value="yes">
-        <label class="govuk-label govuk-radios__label" for="another">Yes</label>
-    </div>
-
-      <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="another-2" name="another" type="radio" value="no">
-        <label class="govuk-label govuk-radios__label" for="another-2">No</label>
-      </div>
-    </div>
-
-  </fieldset>
-
-</div>
-
-<button class="govuk-button" data-module="govuk-button">Continue</button>

--- a/src/examples/file-upload/upload-in-progress/index.njk
+++ b/src/examples/file-upload/upload-in-progress/index.njk
@@ -1,9 +1,6 @@
 ---
 layout: layout-example.njk
 ---
-{% from "hmrc/components/page-heading/macro.njk"  import hmrcPageHeading %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-
 <h1 class="govuk-heading-xl">Upload in progress</h1>
 
-<p class="govuk-body">12% of [filename] uploaded.</p>
+<p class="govuk-body" aria-live="polite">12% of [filename] uploaded.</p>

--- a/src/examples/file-upload/upload-in-progress/index.njk
+++ b/src/examples/file-upload/upload-in-progress/index.njk
@@ -1,6 +1,0 @@
----
-layout: layout-example.njk
----
-<h1 class="govuk-heading-xl">Upload in progress</h1>
-
-<p class="govuk-body" aria-live="polite">12% of [filename] uploaded.</p>

--- a/src/hmrc-design-patterns/file-upload/index.njk
+++ b/src/hmrc-design-patterns/file-upload/index.njk
@@ -41,6 +41,8 @@ status: development
 
 <p class="govuk-body">If users need the option to upload more than one file, include an additional screen asking if they want to upload another.</p>
 
+<p class="govuk-body">Show the status of the file uploads.</p>
+
 {{
   example({
     item: 'file-upload',
@@ -54,18 +56,6 @@ status: development
 <p class="govuk-body">Let users upload as many different file types as possible. Convert them automatically, if you need to.</p>
 
 <p class="govuk-body">If you must limit file types, let users know by using hint text.</p>
-
-<h3 class="govuk-heading-m" id="Upload in progress">Upload in progress</h3>
-
-<p class="govuk-body">Show the user that their file is being uploaded.</p>
-
-{{
-  example({
-    item: 'file-upload',
-    example: 'upload-in-progress',
-    description: 'Upload in progress'
-  })
-}}
 
 <h3 class="govuk-heading-m" id="Error messages">Error messages</h3>
 


### PR DESCRIPTION
Tim... besides the updates I've just made, these are my suggested further changes to the example code:

'You have added 2 receipts' > 'Upload receipts'
'file upload' and '33% uploaded' in their own column
'Change | ' removed

Could you make changes to the preview ahead of our call tomorrow so it's clear what we want?

We might need further guidance on error messages for edge cases. Like what happens if a file upload is still in progress, the user selects no and continue.