### PR TITLE
Moving hint text into paragraph

### DIFF
--- a/src/examples/unique-taxpayer-reference/corporation-tax-welsh/index.njk
+++ b/src/examples/unique-taxpayer-reference/corporation-tax-welsh/index.njk
@@ -7,6 +7,8 @@ layout: layout-example.njk
 
 <h1 class="govuk-heading-l">Beth yw’ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Treth Gorfforaeth (UTR)?</h1>
 
+<p class="govuk-body">Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Treth Gorfforaeth. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’.</p>
+
 <p class="govuk-body">Gallwch <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/dod-o-hyd-i-utr-sydd-ar-goll">ddod o hyd i UTR sydd ar goll (yn agor tab newydd)</a>.</p>
 
 {{
@@ -15,9 +17,6 @@ layout: layout-example.njk
       text: "Beth yw’ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Treth Gorfforaeth?",
       isPageHeading: false,
       classes: "govuk-visually-hidden"
-    },
-    hint: {
-      html: 'Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Treth Gorfforaeth. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’.'
     },
     id: "utr",
     name: "utr",

--- a/src/examples/unique-taxpayer-reference/corporation-tax/index.njk
+++ b/src/examples/unique-taxpayer-reference/corporation-tax/index.njk
@@ -7,6 +7,8 @@ layout: layout-example.njk
 
 <h1 class="govuk-heading-l">What is your Corporation Tax Unique Taxpayer Reference (UTR)?</h1>
 
+<p class="govuk-body">Your UTR can be 10 or 13 digits long. You can find it in your <a class="govuk-link" href="https://www.gov.uk/personal-tax-account">Personal Tax Account</a>, on tax returns and other documents from HMRC. It might be called ‘reference’, ‘UTR’ or ‘official use’.</p>
+
 <p class="govuk-body"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/find-lost-utr-number">Find a lost UTR (opens in new tab)</a>.</p>
 
 {{
@@ -15,9 +17,6 @@ layout: layout-example.njk
       text: "What is your Corporation Tax Unique Taxpayer Reference?",
       isPageHeading: false,
       classes: "govuk-visually-hidden"
-    },
-    hint: {
-      html: 'Your UTR can be 10 or 13 digits long. You can find it in your <a class="govuk-link" href="https://www.gov.uk/personal-tax-account">Personal Tax Account</a>, on tax returns and other documents from HMRC. It might be called ‘reference’, ‘UTR’ or ‘official use’.'
     },
     id: "utr",
     name: "utr",

--- a/src/examples/unique-taxpayer-reference/self-assessment-welsh/index.njk
+++ b/src/examples/unique-taxpayer-reference/self-assessment-welsh/index.njk
@@ -7,6 +7,8 @@ layout: layout-example.njk
 
 <h1 class="govuk-heading-l">Beth yw'ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad (UTR)?</h1>
 
+<p class="govuk-body">Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Hunanasesiad. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’.</p>
+
 <p class="govuk-body">Gallwch <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/dod-o-hyd-i-utr-sydd-ar-goll">ddod o hyd i UTR sydd ar goll (yn agor tab newydd)</a>.</p>
 
 {{
@@ -15,9 +17,6 @@ layout: layout-example.njk
       text: "Beth yw'ch Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad?",
       isPageHeading: false,
       classes: "govuk-visually-hidden"
-    },
-    hint: {
-      html: 'Mae hwn yn cynnwys 10 rhif, er enghraifft 1234567890. Bydd i’w weld ar Ffurflenni Treth a llythyrau eraill ynghylch Hunanasesiad. Efallai y cyfeirir ato gan ddefnyddio’r geiriau ‘cyfeirnod’, ‘UTR’ neu ‘defnydd swyddogol’.'
     },
     id: "utr",
     name: "utr",

--- a/src/examples/unique-taxpayer-reference/self-assessment/index.njk
+++ b/src/examples/unique-taxpayer-reference/self-assessment/index.njk
@@ -7,6 +7,8 @@ layout: layout-example.njk
 
 <h1 class="govuk-heading-l">What is your Self Assessment Unique Taxpayer Reference (UTR)?</h1>
 
+<p class="govuk-body">Your UTR can be 10 or 13 digits long. You can find it in your <a class="govuk-link" href="https://www.gov.uk/personal-tax-account">Personal Tax Account</a>, on tax returns and other documents from HMRC. It might be called ‘reference’, ‘UTR’ or ‘official use’.</p>
+
 <p class="govuk-body"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/find-lost-utr-number">Find a lost UTR (opens in new tab)</a>.</p>
 
 {{ govukInput({
@@ -14,9 +16,6 @@ layout: layout-example.njk
     text: "What is your Self Assessment Unique Taxpayer Reference?",
     isPageHeading: false,
     classes: "govuk-visually-hidden"
-  },
-  hint: {
-      html: 'Your UTR can be 10 or 13 digits long. You can find it in your <a class="govuk-link" href="https://www.gov.uk/personal-tax-account">Personal Tax Account</a>, on tax returns and other documents from HMRC. It might be called ‘reference’, ‘UTR’ or ‘official use’.'
   },
   id: "utr",
   name: "utr",


### PR DESCRIPTION
@Jon-Rowe-HMRC I've moved the hint text back into a paragraph. There was already a visually hidden label so I've left that in. The wording changed when we moved it into hint text, I'm guessing we want to keep the new wording?