### PR TITLE
PLATUI-2649 updated hmrc-frontend dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "govuk-frontend": "4.7.0",
-        "hmrc-frontend": "^5.41.0"
+        "hmrc-frontend": "^5.60.0"
       },
       "devDependencies": {
         "autoprefixer": "^9.6.5",
@@ -8223,9 +8223,9 @@
       }
     },
     "node_modules/hmrc-frontend": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-5.41.0.tgz",
-      "integrity": "sha512-UM6d5vOW+prHarsADLTfHlldOkL0NpZXbnGHyfaSZx63IHXtCPTF3zMl+PTYt9ABLQmpxEH9zyewPHOv6T3vGA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-5.60.0.tgz",
+      "integrity": "sha512-XINFXJTl6mzw6kdFihzqM6Zw/PibzAsIpDKqni5EhPNUA2ldkAdOrPQArWmPb/xN6nyE6OqyGAdj7IZEjBCxtg==",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",
         "govuk-frontend": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/hmrc/design-system#readme",
   "dependencies": {
     "govuk-frontend": "4.7.0",
-    "hmrc-frontend": "^5.41.0"
+    "hmrc-frontend": "^5.60.0"
   },
   "devDependencies": {
     "autoprefixer": "^9.6.5",


### PR DESCRIPTION
# Purpose of PR
- Uplift `hmrc-frontend` to latest version `5.60.0`
- This version of `hmrc-frontend` allows Windows High Contrast Mode users to visibly see what element they have focused on in account-menu items.