### PR TITLE
Updates to Pay for a tax, duty, levy or grant

### DIFF
--- a/src/examples/pay-for-a-tax/Approve-a-payment-through-your-online-bank-account-markdown/index.md
+++ b/src/examples/pay-for-a-tax/Approve-a-payment-through-your-online-bank-account-markdown/index.md
@@ -1,7 +1,9 @@
-## Approve a payment through your online bank account
+## Paying online through your bank account
 
 You can pay by approving a payment through your online bank account by selecting the ‘pay by bank account’ option.
 
 You will be directed to sign in to your online or mobile banking account to approve your payment.
+
+You will need to have your online banking details to hand to pay this way.
 
 The payment is usually instant but can sometimes take up to 2 hours to show in your account.

--- a/src/examples/pay-for-a-tax/Approve-a-payment-through-your-online-bank-account/index.njk
+++ b/src/examples/pay-for-a-tax/Approve-a-payment-through-your-online-bank-account/index.njk
@@ -3,7 +3,7 @@ layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<h3 class="govuk-heading-l">Approve a payment through your online bank account</h3>
+<h3 class="govuk-heading-l">Paying online through your bank account</h3>
 
 <p class="govuk-body">
 You can pay by approving a payment through your online bank account by selecting the ‘pay by bank account’ option.
@@ -11,6 +11,10 @@ You can pay by approving a payment through your online bank account by selecting
 
 <p class="govuk-body">
 You will be directed to sign in to your online or mobile banking account to approve your payment.
+</p>
+
+<p class="govuk-body">
+You will need to have your online banking details to hand to pay this way.
 </p>
 
 <p class="govuk-body">

--- a/src/examples/pay-for-a-tax/Make-a-single-payment-markdown/index.md
+++ b/src/examples/pay-for-a-tax/Make-a-single-payment-markdown/index.md
@@ -1,4 +1,4 @@
-### Make a single payment
+### Making a single payment
 
 You’ll need to set up a payment each time you pay HMRC. 
 
@@ -9,7 +9,7 @@ You should set up the payment at least:
 
 The payments will show on your bank statement as ‘HMRC NDDS’.
 
-### Pay your bill automatically
+### Paying your bill automatically
 
 HMRC will automatically collect the payment from your bank account based on the amount in your return. You’ll only need to set the Direct Debit up once.
 

--- a/src/examples/pay-for-a-tax/Make-a-single-payment/index.njk
+++ b/src/examples/pay-for-a-tax/Make-a-single-payment/index.njk
@@ -3,7 +3,7 @@ layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<h3 class="govuk-heading-l">Make a single payment</h3>
+<h3 class="govuk-heading-l">Making a single payment</h3>
 
 <p class="govuk-body">
 You’ll need to set up a payment each time you pay HMRC. 
@@ -22,7 +22,7 @@ You should set up the payment at least:
 The payments will show on your bank statement as ‘HMRC NDDS’.
 </p>
 
-<h3 class="govuk-heading-l">Pay your bill automatically</h3>
+<h3 class="govuk-heading-l">Paying your bill automatically</h3>
 
 <p class="govuk-body">
 HMRC will automatically collect the payment from your bank account based on the amount in your return. You’ll only need to set the Direct Debit up once. 

--- a/src/examples/pay-for-a-tax/Pay-by-debit-or-corporate-credit-card-markdown/index.md
+++ b/src/examples/pay-for-a-tax/Pay-by-debit-or-corporate-credit-card-markdown/index.md
@@ -1,4 +1,4 @@
-## Pay by debit or corporate credit card
+## Paying by debit or corporate credit card
 
 You can make a full payment online using a debit or corporate credit card. There is a non-refundable fee if you use a corporate credit or debit card. You cannot pay by personal credit card.
 
@@ -6,4 +6,4 @@ Your payment will be accepted on the date you make it and not the date it reache
 
 You must make sure the details you enter match those held by your bank or card provider. For example, the billing address should match the one your card is currently registered with.
 
-{button start}[Start now](link to online service){/button}
+

--- a/src/examples/pay-for-a-tax/Pay-by-debit-or-corporate-credit-card/index.njk
+++ b/src/examples/pay-for-a-tax/Pay-by-debit-or-corporate-credit-card/index.njk
@@ -3,7 +3,7 @@ layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<h3 class="govuk-heading-l">Pay by debit or corporate credit card</h3>
+<h3 class="govuk-heading-l">Paying by debit or corporate credit card</h3>
 
 <p class="govuk-body">
 You can make a full payment online using a debit or corporate credit card. There is a non-refundable fee if you use a corporate credit or debit card. You cannot pay by personal credit card.
@@ -17,7 +17,3 @@ Your payment will be accepted on the date you make it and not the date it reache
 You must make sure the details you enter match those held by your bank or card provider. For example, the billing address should match the one your card is currently registered with.
 </p>
 
-{{ govukButton({
-  text: "Start now",
-  isStartButton: true
-}) }}

--- a/src/examples/pay-for-a-tax/Pay-online-with-green-button-markdown/index.md
+++ b/src/examples/pay-for-a-tax/Pay-online-with-green-button-markdown/index.md
@@ -1,0 +1,9 @@
+## Pay online
+
+You can pay online using one of the following methods:
+
+* approve a payment through your online bank account
+* Direct Debit
+* debit or corporate credit card
+
+{button start}[Start now](link to online service){/button}

--- a/src/examples/pay-for-a-tax/Pay-online-with-green-button/index.njk
+++ b/src/examples/pay-for-a-tax/Pay-online-with-green-button/index.njk
@@ -12,7 +12,7 @@ You can pay online using one of the following methods:
 <ul class="govuk-list govuk-list--bullet">
 <li>approve a payment through your online bank account</li>
 <li>Direct Debit</li>
-<li>3 debit or corporate credit card</li>
+<li>debit or corporate credit card</li>
 </ul>
 
 {{ govukButton({

--- a/src/examples/pay-for-a-tax/Pay-online-with-green-button/index.njk
+++ b/src/examples/pay-for-a-tax/Pay-online-with-green-button/index.njk
@@ -1,0 +1,21 @@
+---
+layout: layout-example.njk
+---
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+<h3 class="govuk-heading-l">Pay online</h3>
+
+<p class="govuk-body">
+You can pay online using one of the following methods: 
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+<li>approve a payment through your online bank account</li>
+<li>Direct Debit</li>
+<li>3 debit or corporate credit card</li>
+</ul>
+
+{{ govukButton({
+  text: "Start now",
+  isStartButton: true
+}) }}

--- a/src/examples/pay-for-a-tax/pay-online-markdown/index.md
+++ b/src/examples/pay-for-a-tax/pay-online-markdown/index.md
@@ -1,4 +1,4 @@
-## Paying online by direct debit
+## Paying online by Direct Debit
 
 Set up a Direct Debit through your HMRC online account.
 

--- a/src/examples/pay-for-a-tax/pay-online-markdown/index.md
+++ b/src/examples/pay-for-a-tax/pay-online-markdown/index.md
@@ -1,5 +1,4 @@
-## Pay online
-### Pay by Direct Debit
+## Paying online by direct debit
 
 Set up a Direct Debit through your HMRC online account.
 

--- a/src/examples/pay-for-a-tax/pay-online/index.njk
+++ b/src/examples/pay-for-a-tax/pay-online/index.njk
@@ -3,9 +3,7 @@ layout: layout-example.njk
 ---
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<h2 class="govuk-heading-l">Pay online</h2>
-
-<h3 class="govuk-heading-m">Pay by Direct Debit</h3>
+<h2 class="govuk-heading-l">Paying online by Direct Debit</h2>
 
 <p class="govuk-body">
 Set up a Direct Debit through your HMRC online account.

--- a/src/patterns-hmrc-govuk-team/pay-for-a-tax-duty-levy-or-grant/index.njk
+++ b/src/patterns-hmrc-govuk-team/pay-for-a-tax-duty-levy-or-grant/index.njk
@@ -36,16 +36,13 @@ For an example of the pattern in use, go to <a href="https://www.gov.uk/guidance
 <h3 class="govuk-heading-m">Body</h3>
 
 <p class="govuk-body">
-There are 3 optional payment methods that you may need to include:
+There are 5 optional payment methods that you may need to include:
 </p>
 
 <ol class="govuk-list govuk-list--number">
-    <li>Pay online – this section may include one or more of the following subheadings: 
-    <ul class="govuk-list govuk-list--bullet">
-    <li>Pay by Direct Debit</li>
-    <li>Approve a payment through your online bank account</li>
+    <li>Pay through your online bank account</li>
+    <li>Pay by Direct Debit </li>
     <li>Pay by debit or corporate credit card </li>
-  </ul>
     <li>Pay by bank transfer (this can include payments for both UK and overseas accounts)</li>
     <li>Pay by cheque</li>
   </ol>
@@ -91,8 +88,19 @@ Then include the following:
     markdownWelsh: 'what-you-need-welsh-markdown',
     markdownOnly: true
 }) }}
-<h3 class="govuk-heading-m">Pay online</h3>
-<p class="govuk-body">If there are multiple methods of paying online, separate the methods by using a heading 3.</p>
+<h3 class="govuk-heading-m">Online payment methods</h3>
+<p class="govuk-body">Start with the businesses’ preferred method, through your bank account, and follow with Direct Debit, if customers can pay that way.
+    </p>
+    {{ example({
+        item: 'pay-for-a-tax',
+        example: 'Approve-a-payment-through-your-online-bank-account',
+        description: 'Approve a payment through your online bank account',
+        markdown: 'Approve-a-payment-through-your-online-bank-account-markdown',
+        welsh: 'bank-transfer-welsh',
+        markdownWelsh: 'bank-transfer-welsh-markdown',
+        markdownOnly: true
+    }) }}
+    <p class="govuk-body">If there are two ways to pay by Direct Debit, separate the methods by using a heading 3. If only one method can be used, a heading will not be needed.</p>
 {{ example({
     item: 'pay-for-a-tax',
     example: 'pay-online',
@@ -102,7 +110,7 @@ Then include the following:
     markdownWelsh: 'pay-online-welsh-markdown',
     markdownOnly: true
 }) }}
-<p class="govuk-body">If there are two ways to pay by Direct Debit, separate the methods by using a heading 3. If only one method can be used, a heading will not be needed.</p>
+
 {{ example({
     item: 'pay-for-a-tax',
     example: 'Make-a-single-payment',
@@ -115,19 +123,22 @@ Then include the following:
 
 {{ example({
     item: 'pay-for-a-tax',
-    example: 'Approve-a-payment-through-your-online-bank-account',
-    description: 'Approve a payment through your online bank account',
-    markdown: 'Approve-a-payment-through-your-online-bank-account-markdown',
+    example: 'Pay-by-debit-or-corporate-credit-card',
+    description: 'Pay by debit or corporate credit card',
+    markdown: 'Pay-by-debit-or-corporate-credit-card-markdown',
     welsh: 'bank-transfer-welsh',
     markdownWelsh: 'bank-transfer-welsh-markdown',
     markdownOnly: true
 }) }}
+<h3 class="govuk-heading-m">Green button for online payment methods</h3>
+<p class="govuk-body">For accessibility the green ‘pay now’ button must be under a heading and section that refers to all online payment methods. This is so screen reader users understand that the button applies to all payment methods under this heading. 
+</p>
 
 {{ example({
     item: 'pay-for-a-tax',
-    example: 'Pay-by-debit-or-corporate-credit-card',
-    description: 'Pay by debit or corporate credit card',
-    markdown: 'Pay-by-debit-or-corporate-credit-card-markdown',
+    example: 'pay-online-with-green-button',
+    description: 'Pay online',
+    markdown: 'pay-online-with-green-button-markdown',
     welsh: 'bank-transfer-welsh',
     markdownWelsh: 'bank-transfer-welsh-markdown',
     markdownOnly: true

--- a/src/patterns-hmrc-govuk-team/pay-for-a-tax-duty-levy-or-grant/index.njk
+++ b/src/patterns-hmrc-govuk-team/pay-for-a-tax-duty-levy-or-grant/index.njk
@@ -156,7 +156,7 @@ Then include the following:
     markdownWelsh: 'bank-transfer-welsh-markdown',
     markdownOnly: true
 }) }}
-
+<h3 class="govuk-heading-m">Pay by cheque</h3>
 {{ example({
     item: 'pay-for-a-tax',
     example: 'cheque',


### PR DESCRIPTION
Text updates to guidance and examples. Also reordered examples and added a new example around online payments. The team have requested changes to the gerund '-ing' form in some examples in line with this guidance from GDS:

"Using ‘ing’ in titles
Use the active verb (‘Submit’) if you use the page to do the thing.
Good form title example: Submit your business expenses
Use the present participle (‘Submitting’) if the page is about doing the thing, but you do it elsewhere.
Good guidance title example: Submitting your business expenses"

I've also asked the team to supply the Welsh translation for the new example. 