### PR TITLE
sign-out-name-change

### DIFF
--- a/src/examples/sign-out/example-welsh/index.njk
+++ b/src/examples/sign-out/example-welsh/index.njk
@@ -4,7 +4,6 @@ layout: layout-example.njk
 {% from "hmrc/components/header/macro.njk" import hmrcHeader %}
 
 {{ hmrcHeader({
-  serviceName: "Enw'r gwasanaeth",
   serviceUrl : "/",
   phaseBanner : {
     tag: {

--- a/src/examples/sign-out/example/index.njk
+++ b/src/examples/sign-out/example/index.njk
@@ -4,7 +4,6 @@ layout: layout-example.njk
 {% from "hmrc/components/header/macro.njk" import hmrcHeader %}
 
 {{ hmrcHeader({
-  serviceName: "Service Name",
   serviceUrl : "/",
   phaseBanner : {
     tag: {


### PR DESCRIPTION
We've removed the service name from the header. We haven't changed the sign out part but it should match the baseline of the GOV.UK sign