### PR TITLE
Adding in autocomplete attributes

### DIFF
--- a/src/examples/addresses/country/index.njk
+++ b/src/examples/addresses/country/index.njk
@@ -13,7 +13,8 @@ layout: layout-example.njk
       isPageHeading: true
     },
     id: "example",
-    name: "example"
+    name: "example",
+    autocomplete: "country-name"
   }) }}
 
   {{ govukButton({

--- a/src/examples/addresses/find/index.njk
+++ b/src/examples/addresses/find/index.njk
@@ -14,7 +14,8 @@ layout: layout-example.njk
     },
     id: "postcode",
     name: "postcode",
-    classes: "govuk-input--width-10"
+    classes: "govuk-input--width-10",
+    autocomplete: "postal-code"
   })
 }}
 

--- a/src/examples/addresses/manual/index.njk
+++ b/src/examples/addresses/manual/index.njk
@@ -20,7 +20,8 @@ layout: layout-example.njk
       text: "Organisation (optional)"
     },
     id: "organisation",
-    name: "organisation"
+    name: "organisation",
+    autocomplete: "organization"
   })
 }}
 
@@ -41,7 +42,8 @@ layout: layout-example.njk
       text: "Address line 2 (optional)"
     },
     id: "line2",
-    name: "line2"
+    name: "line2",
+    autocomplete: "address-line2"
   })
 }}
 
@@ -51,7 +53,8 @@ layout: layout-example.njk
       text: "Town or city"
     },
     id: "town-city",
-    name: "town-city"
+    name: "town-city",
+    autocomplete: "address-level2"
   })
 }}
 
@@ -72,7 +75,8 @@ layout: layout-example.njk
     },
     id: "postcode",
     name: "postcode",
-    classes: "govuk-input--width-10"
+    classes: "govuk-input--width-10",
+    autocomplete: "postal-code"
   })
 }}
 
@@ -82,7 +86,8 @@ layout: layout-example.njk
       text: "Country"
     },
     id: "country",
-    name: "country"
+    name: "country",
+    autocomplete: "country-name"
   })
 }}
 


### PR DESCRIPTION
There's some odd behaviour when autocomplete on this page because there's multiples of some inputs e.g. post codes. The examples work fine when opening in a new tab though. I can't see a way of isolating them other than having them on separate pages.