### PR TITLE
Remove account header reference from notification badge

### DIFF
--- a/src/hmrc-design-patterns/notification-badge/index.njk
+++ b/src/hmrc-design-patterns/notification-badge/index.njk
@@ -7,7 +7,7 @@ layout: twoColumnPage.njk
 
 {% block content %}
 
-<p class="govuk-body">This pattern lets the user know that there is new information to view, like unread messages, and how many of them there are. The notification badge is part of the <a class="govuk-link" href="/hmrc-design-patterns/account-header">account header</a>.</p>
+<p class="govuk-body">This pattern lets the user know that there is new information to view, like unread messages, and how many of them there are.</p>
 
 <h2 class="govuk-heading-l" id="when-to-use">When to use</h2>
 


### PR DESCRIPTION
Deleted mention of the notification badge being part of the account header.