### PR TITLE
Remove 'When not to use' section from Welsh toggle

### DIFF
--- a/src/hmrc-design-patterns/welsh-language-toggle/index.njk
+++ b/src/hmrc-design-patterns/welsh-language-toggle/index.njk
@@ -16,14 +16,6 @@ layout: twoColumnPage.njk
 
 <p class="govuk-body">Use the Welsh language toggle when a service is available in Welsh.</p>
 
-<h2 id="when-not-to-use" class="govuk-heading-l">When not to use</h2>
-
-<p class="govuk-body">Do not use the Welsh language toggle:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>where there is no Welsh translation for a service</li>
-  <li>in personal tax account services — use the <a class="govuk-link" href="/hmrc-design-patterns/account-header/">account header</a> which already has a Welsh language toggle</li>
-</ul>
-
 <h2 id="how-it-works" class="govuk-heading-l">How it works</h2>
 
 {{ hmrcFrontendInfo() }}


### PR DESCRIPTION
Not needed now there is no account header pattern exception