### PR TITLE
Update backlog table entries

### DIFF
--- a/src/hmrc-design-patterns/hmrc-design-patterns-backlog/index.njk
+++ b/src/hmrc-design-patterns/hmrc-design-patterns-backlog/index.njk
@@ -35,18 +35,18 @@ layout: twoColumnPage.njk
     rows: [
       [
         {
-          html: '<a class="govuk-link" href="https://github.com/hmrc/design-patterns/issues/178">Addresses</a>'
-        },
-        {
-          text: 'In progress'
-        }
-      ],
-      [
-        {
           html: '<a class="govuk-link" href="https://github.com/hmrc/design-patterns/issues/166">Bank account verification</a>'
         },
         {
           text: 'Proposed'
+        }
+      ],
+      [
+        {
+          html: '<a class="govuk-link" href="https://github.com/hmrc/design-patterns/issues/174">Caseworker guidance banner</a>'
+        },
+        {
+          text: 'In progress'
         }
       ],
       [
@@ -56,24 +56,7 @@ layout: twoColumnPage.njk
         {
           text: 'Proposed'
         }
-      ],
-     [
-        {
-          html: '<a class="govuk-link" href="https://github.com/hmrc/design-patterns/issues/71">Email</a>'
-        },
-        {
-          text: 'Proposed'
-        }
-      ],
-             [
-        {
-          html: '<a class="govuk-link" href="https://github.com/hmrc/design-patterns/issues/174">Instructional caption</a>'
-        },
-        {
-          text: 'Proposed'
-        }
       ]
-
     ]
   })
 }}


### PR DESCRIPTION
Removed the 'Addresses' and 'Email' rows, renamed 'Instructional caption' to 'Caseworker guidance banner' and changed status to 'In progress'