### PR TITLE
Update Palestine entry

### DIFF
--- a/src/examples/addresses/country/index.njk
+++ b/src/examples/addresses/country/index.njk
@@ -198,7 +198,7 @@ layout: layout-example.njk
         { value: "OM-Oman", text: "Oman"},
         { value: "PK-Pakistan", text: "Pakistan"},
         { value: "PW-Palau", text: "Palau"},
-        { value: "PS-Palestine,_State_of", text: "Palestine, State of"},
+        { value: "PS-Occupied_Palestinian_Territories", text: "Occupied Palestinian Territories"},
         { value: "PA-Panama", text: "Panama"},
         { value: "PG-Papua_New_Guinea", text: "Papua New Guinea"},
         { value: "PY-Paraguay", text: "Paraguay"},


### PR DESCRIPTION
Changed the country value and label to 'Occupied Palestinian Territories' in the address example to reflect FCDO naming conventions.