### PR TITLE
PLATUI-3945 bump hmrc-frontend to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "govuk-frontend": "^5.11.1",
-        "hmrc-frontend": "^6.90.0"
+        "hmrc-frontend": "^6.93.0"
       },
       "devDependencies": {
         "@metalsmith/in-place": "^5.0.0",
@@ -7984,9 +7984,9 @@
       }
     },
     "node_modules/hmrc-frontend": {
-      "version": "6.90.0",
-      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-6.90.0.tgz",
-      "integrity": "sha512-W9mqeLvW+V5EG8nhLBtcXzjxFMIzfw9hzynEN4H8ul4WbXngFtm0BUW3QttGGly3pJ/MYt0cr//CXt/0dNR4UQ==",
+      "version": "6.93.0",
+      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-6.93.0.tgz",
+      "integrity": "sha512-cVE9ItXNZwq9bgCr6n644KbNTnn2Z21/xEZ34jAsTuEg75c7OBE8hrATiPaCrAkqWy3Uta3wyul5f/4fSd1Iag==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/hmrc/design-system#readme",
   "dependencies": {
     "govuk-frontend": "^5.11.1",
-    "hmrc-frontend": "^6.90.0"
+    "hmrc-frontend": "^6.93.0"
   },
   "devDependencies": {
     "@metalsmith/in-place": "^5.0.0",


### PR DESCRIPTION
# Purpose of PR
- Bump hmrc-frontend to latest (`6.93.0`)
   - This removes unused `data-journey-click` attributes in `header`, `language-select` and `service-navigation-language-select` components