### PR TITLE
What's new: Research banner

### DIFF
--- a/application/templates/partials/whatsNew.njk
+++ b/application/templates/partials/whatsNew.njk
@@ -2,9 +2,9 @@
   <h2 id="whats-new" class="govuk-heading-m">What’s new</h2>
 
   <ul class="govuk-list govuk-list--bullet">
+  <li>20 April 2026: <a href="/hmrc-design-patterns/research-banner/" class="govuk-link">Research banner</a> updated (<a href="https://github.com/hmrc/design-system/pull/1132/changes" class="govuk-link">changes</a>)</li>
   <li>8 April 2026: <a href="/patterns-hmrc-govuk-team/sign-in-to-use-a-service/" class="govuk-link">Sign in to use a service</a> updated (<a href="https://github.com/hmrc/design-system/pull/1126/changes" class="govuk-link">changes</a>)</li>
   <li>24 March 2026: <a href="/hmrc-design-patterns/caseworker-guidance-banner/" class="govuk-link">Caseworker guidance banner</a> published</li>
-  <li>23 March 2026: <a href="/patterns-hmrc-govuk-team/green-button/" class="govuk-link">Green button</a> updated (<a href="https://github.com/hmrc/design-system/pull/1116/changes" class="govuk-link">changes</a>)</li>
 </ul>
 
   <p class="govuk-body">


### PR DESCRIPTION
Add 20 April 2026 'Research banner' entry and remove the 23 March 2026 'Green button' entry in the What's new partial to reflect the latest site updates.