### PR TITLE
Addresses: change country field label to 'Enter your country'

### DIFF
--- a/src/examples/addresses/country/index.njk
+++ b/src/examples/addresses/country/index.njk
@@ -12,7 +12,7 @@ accessibleAutocompleteAssets: true
       id: "location-picker-select",
       name: "location-picker-select",
       label: {
-        text: "Select your country",
+        text: "Enter your country",
         classes: "govuk-label--l",
         isPageHeading: true
       },


### PR DESCRIPTION
Change the label text for the country input in the addresses example from 'Select your country' to 'Enter your country' to better reflect the input method (autocomplete/free text). Modified src/examples/addresses/country/index.njk for the location-picker-select field; no other changes.