### PR TITLE
Open in example in new tab shows correct language example

### DIFF
--- a/application/assets/javascripts/components/language-switch-example.js
+++ b/application/assets/javascripts/components/language-switch-example.js
@@ -5,6 +5,7 @@ function LanguageSwitchExample ($module) {
   this.$switches = this.$module.querySelectorAll('.app-example__language-switch a')
   this.$iframe = this.$module.querySelector('[data-module~="app-example-frame"]')
   this.currentClassName = 'app-example__language-switch--current'
+  this.$newTabLink = this.$module.querySelector('.app-example__new-tab a')
   this.getLanguageClass = function (lang) {
     return ['app-example__language-switch--', lang, '-activated'].join('')
   }
@@ -35,6 +36,11 @@ LanguageSwitchExample.prototype.handleClick = function (event) {
   $target.parentNode.classList.add(this.currentClassName)
   this.$module.classList.remove(this.getLanguageClass('en'), this.getLanguageClass('cy'))
   this.$module.classList.add(this.getLanguageClass($target.getAttribute('data-lang')))
+
+  this.newTabhref = this.$newTabLink.getAttribute('href')
+  this.newTabAltHref = this.$newTabLink.getAttribute('data-alt-href')
+  this.$newTabLink.setAttribute('href', this.newTabAltHref)
+  this.$newTabLink.setAttribute('data-alt-href', this.newTabhref)
 }
 
 export default LanguageSwitchExample

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -44,7 +44,7 @@
 
     <div class="app-example app-example--tabs">
       <span class="app-example__link app-example__new-tab">
-        <a href="{{ newTabExampleURL }}" target="_blank" title="Open {{description}} example in a new tab">
+        <a href="{{ newTabExampleURL }}" {% if newTabWelshExampleURL %}data-alt-href="{{ newTabWelshExampleURL }}"{% endif %} target="_blank" title="Open {{description}} example in a new tab">
           Open this example in a new tab<span class="govuk-visually-hidden">: {{description}}</span>
         </a>
       </span>


### PR DESCRIPTION
This fixes a bug where when you switch the language to Welsh in an example and then press the open example in new tab button, it opens in English. This fixes this so that whatever language is showing in the preview, the new tab example will be the same 