### PR TITLE
Archived exchange rates

### DIFF
--- a/src/patterns-hmrc-govuk-team/exchange-rates-yearly-averages-and-spot-rates/index.njk
+++ b/src/patterns-hmrc-govuk-team/exchange-rates-yearly-averages-and-spot-rates/index.njk
@@ -1,6 +1,6 @@
 ---
 title: 'Exchange rates: yearly averages and spot rates'
-status: development
+status: archived
 layout: twoColumnPage.njk
 ---
 {% from "_codeSnippet.njk" import codeSnippet %}


### PR DESCRIPTION
Archiving a pattern that was stuck in development - the GOV.UK team have confirmed that we can can retire it. 

The pattern never made it out of development so do we need to update the "What's New" section? I'll sort this if we think we need it. Just wondering for future cases like this as there is another development pattern that the team may want to archive.