### PR TITLE
Focus styles for code examples

### DIFF
--- a/application/scss/components/_codeSnippet.scss
+++ b/application/scss/components/_codeSnippet.scss
@@ -17,6 +17,11 @@ code:not(.hljs) {
       white-space: pre-wrap;
       color: $black;
       padding: 0;
+
+      &:focus {
+        border: 3px solid var(--govuk-input-border-colour, #0b0c0c);
+        outline: 3px solid var(--govuk-focus-colour, #fd0);
+      }
     }
   }
 

--- a/application/scss/components/_pane.scss
+++ b/application/scss/components/_pane.scss
@@ -58,7 +58,7 @@
       margin-left: auto;
       flex: 1 1 auto;
       flex-direction: column;
-      align-items: flex-start;
+      min-width: 0; // Fixes pre element being wider than we want due to flex items automatic minimum size
 
       // Stick footer to bottom of screen if content is shorter than viewport
       main {

--- a/application/scss/components/_tabs.scss
+++ b/application/scss/components/_tabs.scss
@@ -127,14 +127,21 @@
 
 .app-tabs__container pre code {
   display: block;
+  padding-top: 48px; // button height + border + top/bottom position
   padding-right: govuk-spacing(4);
   padding-bottom: govuk-spacing(4);
   overflow-x: auto;
+  border: 3px solid transparent;
+
+  &:focus {
+    border-color: var(--govuk-input-border-colour, #0b0c0c);
+    outline: 3px solid var(--govuk-focus-colour, #fd0);
+  }
 }
 
 .app-tabs__container pre {
-  padding-right: 0;
-  padding-bottom: 0;
+  overflow: visible;
+  padding: 0;
 }
 
 

--- a/application/templates/partials/_codeSnippet.njk
+++ b/application/templates/partials/_codeSnippet.njk
@@ -2,12 +2,12 @@
   {% if params.code %}
     <div class="app-code-snippet{%if params.canCopy%} app-code-snippet--copy{% endif %}">
       <pre {% if params.canCopy %}data-module="app-copy"{% endif %}><code class="govuk-body-s">
-        {%- if params.isSafe -%}
-          {{- params.code | safe -}}
-        {%- else -%}
-          {{- params.code -}}
-        {%- endif -%}
-      </code></pre>
+          {%- if params.isSafe -%}
+            {{- params.code | safe -}}
+          {%- else -%}
+            {{- params.code -}}
+          {%- endif -%}
+        </code></pre>
     </div>
   {% endif %}
 {% endmacro %}

--- a/application/templates/partials/_example.njk
+++ b/application/templates/partials/_example.njk
@@ -96,18 +96,14 @@
 
         {% if not params.markdownOnly %}
           <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-html" role="tabpanel">
-            <pre class="app-example__language-switch--en-only-content" data-module="app-copy">
-              <code class="hljs html">
+            <pre class="app-example__language-switch--en-only-content" data-module="app-copy"><code class="hljs html" tabindex="0">
                 {{- getHTMLCode(newTabExamplePath) | highlight('html') | safe -}}
-              </code>
-            </pre>
+              </code></pre>
 
             {% if welshExamplePath %}
-              <pre class="app-example__language-switch--cy-only-content" data-module="app-copy">
-                <code class="hljs html">
+              <pre class="app-example__language-switch--cy-only-content" data-module="app-copy"><code class="hljs html" tabindex="0">
                   {{- getHTMLCode(newTabWelshExamplePath) | highlight('html') | safe -}}
-                </code>
-              </pre>
+                </code></pre>
             {% endif %}
           </div>
         {% endif %}
@@ -115,18 +111,14 @@
         {% if not params.htmlOnly %}
           {% if not params.markdownOnly %}
             <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-nunjucks" role="tabpanel">
-              <pre class="app-example__language-switch--en-only-content" data-module="app-copy">
-                <code class="hljs js">
+              <pre class="app-example__language-switch--en-only-content" data-module="app-copy"><code class="hljs js" tabindex="0">
                 {{- getNunjucksCode(newTabExamplePath) | highlight('js') | safe -}}
-                </code>
-              </pre>
+                </code></pre>
 
               {% if welshExamplePath %}
-                <pre class="app-example__language-switch--cy-only-content" data-module="app-copy">
-                  <code class="hljs js">
+                <pre class="app-example__language-switch--cy-only-content" data-module="app-copy"><code class="hljs js" tabindex="0">
                     {{- getNunjucksCode(newTabWelshExamplePath) | highlight('js') | safe -}}
-                  </code>
-                </pre>
+                  </code></pre>
               {% endif %}
             </div>
           {% endif %}
@@ -135,18 +127,14 @@
         {% if not params.htmlOnly %}
           {% if params.markdown %}
             <div class="app-tabs__container js-tabs__container" id="{{ exampleId }}-markdown" role="tabpanel">
-              <pre class="app-example__language-switch--en-only-content" data-module="app-copy">
-                <code class="hljs md">
+              <pre class="app-example__language-switch--en-only-content" data-module="app-copy"><code class="hljs md" tabindex="0">
                   {{- getHTMLCode(markdownExamplePath) | highlight('md') | safe -}}
-                </code>
-              </pre>
+                </code></pre>
 
               {% if welshExamplePath %}
-                <pre class="app-example__language-switch--cy-only-content" data-module="app-copy">
-                  <code class="hljs md">
+                <pre class="app-example__language-switch--cy-only-content" data-module="app-copy"><code class="hljs md" tabindex="0">
                     {{- getHTMLCode(markdownWelshExamplePath) | highlight('md') | safe -}}
-                  </code>
-                </pre>
+                  </code></pre>
               {% endif %}
             </div>
           {% endif %}

--- a/src/hmrc-design-patterns/page-title/index.njk
+++ b/src/hmrc-design-patterns/page-title/index.njk
@@ -29,8 +29,7 @@ title: Page title
 
   {{
     codeSnippet({
-      code: '
-{% block page_title %}
+      code: '{% block page_title %}
   Do you live in the UK? — Your details — Manage your tax credits — GOV.UK
 {% endblock %}',
       canCopy: true


### PR DESCRIPTION
This PR adds focus styles to code examples. Previously the code example were focusable but only had the default browser styles. This PR adds GOV.UK styles to the code elements

Before: 
<img width="1560" height="1454" alt="Screen Shot 2026-07-29 at 15 17 20" src="https://github.com/user-attachments/assets/a381a8f3-6bff-4f2e-ae09-b4d88757c572" />

After:
<img width="1560" height="1372" alt="Screen Shot 2026-07-29 at 15 19 02" src="https://github.com/user-attachments/assets/999a0e99-67c1-4cc9-99b5-03dab79395c0" />

Additional to this the PR fixes a bug which displayed at certain browser widths where the code examples (the pre element specifically) would force its container to be a certain size and therefore would not squash to the correct size.

Before:
<img width="1528" height="1424" alt="Screen Shot 2026-07-29 at 15 18 04" src="https://github.com/user-attachments/assets/d4b13e45-2d64-482c-87a5-d43c541c4275" />

After:
<img width="778" height="1342" alt="Screen Shot 2026-07-29 at 15 19 21" src="https://github.com/user-attachments/assets/b1564f41-f408-4faa-9584-87524e88dc79" />
